### PR TITLE
change the name so `yarn install` can install the deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "name": "Firenvim",
   "scripts": {
     "build": "tslint --fix --project . && webpack && web-ext build --source-dir target/firefox --artifacts-dir target/xpi --overwrite-dest",
-    "install": "nvim --headless -c ':set rtp+=.' -c 'call firenvim#install()' -c 'quit' || true",
+    "iinstall": "nvim --headless -c ':set rtp+=.' -c 'call firenvim#install()' -c 'quit' || true",
     "clean": "rm -rf target"
   },
   "version": "0.1.7"


### PR DESCRIPTION
not a great name, but it does not clash with the defined `install` command of yarn.