### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ let g:firenvim_config = {
         \ '.*': {
             \ 'selector': '',
             \ 'priority': 0,
-        \ }
+        \ },
         \ 'github\.com': {
             \ 'selector': 'textarea',
             \ 'priority': 1,
-        \ }
+        \ },
     \ }
 \ }
 ```


### PR DESCRIPTION
A comma is missing in the example config which causes the following
error on start:
```
Error detected while processing /home/dani/.config/nvim/init.vim:
line  708:
E722: Missing comma in Dictionary: 'github\.com': { 'selector': 'textarea', 'priority':
 1, } } }
E15: Invalid expression: { 'localSettings': { '.*': { 'selector': '', 'priority': 0, }
'github\.com': { 'selector': 'textarea', 'priority': 1, } } }
Press ENTER or type command to continue
```