### PR TITLE
autoload/firenvim.vim: unset NVIM_LISTEN_ADDRESS

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -171,6 +171,7 @@ function! s:get_executable_content(data_dir, prolog)
         endif
         return "#!/bin/sh\n" .
                                 \ "cd " . a:data_dir . "\n" .
+                                \ "unset NVIM_LISTEN_ADDRESS\n" .
                                 \ 'export PATH="$PATH:' . $PATH . "\"\n" .
                                 \ a:prolog . "\n" .
                                 \ "exec '" . s:get_progpath() . "' --headless -c 'call firenvim#run()'\n"


### PR DESCRIPTION
When firefox was started from a shell running in neovim, firenvim would
connect to this neovim instead of the new instance. Unsetting
NVIM_LISTEN_ADDRESS fixes that.