### PR TITLE
Document plugin install methods that have hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firenvim [![Build Status](https://travis-ci.org/glacambre/firenvim.svg?branch=master)](https://travis-ci.org/glacambre/firenvim)[![Build status](https://ci.appveyor.com/api/projects/status/kboak3f5kl9hkgf4/branch/master?svg=true)](https://ci.appveyor.com/project/glacambre/firenvim/branch/master)[![Total alerts](https://img.shields.io/lgtm/alerts/g/glacambre/firenvim.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/glacambre/firenvim/alerts/)
+# Firenvim [![Build Status](https://travis-ci.org/glacambre/firenvim.svg?branch=master)](https://travis-ci.org/glacambre/firenvim) [![Build status](https://ci.appveyor.com/api/projects/status/kboak3f5kl9hkgf4/branch/master?svg=true)](https://ci.appveyor.com/project/glacambre/firenvim/branch/master) [![Total alerts](https://img.shields.io/lgtm/alerts/g/glacambre/firenvim.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/glacambre/firenvim/alerts/)
 
 Turn your browser into a Neovim client.
 
@@ -6,15 +6,15 @@ Turn your browser into a Neovim client.
 
 # How to use
 
-Just click on textareas, the firenvim frame should pop up. When you want to set the content of the textarea to the content of the neovim frame, just `:w`. When you want to close the neovim frame, just `:q`.
+Just click on any textarea and it will be immediately replaced by an instance of Firenvim. When you want to set the content of the now hidden textarea to the content of the Neovim instance, just `:w`. If you want to close the Firenvim overlay and return to the textarea run `:q`.
 
 # Installing
 
-Before installing anything, please read [SECURITY.md](SECURITY.md) and make sure you're OK with everything mentionned in there. If you think of a way to compromise Firenvim, please send me an email (you can find my address in my commits).
+Before installing anything please read [SECURITY.md](SECURITY.md) and make sure you're okay with everything mentioned. In the event you think of a way to compromise Firenvim, please send me an email (you can find my address in my commits).
 
 ## Pre-built
 
-1. Make make sure you are using [Neovim][nvim] 0.4.0 or later. This plugin will not work with vanilla [VIM][vim].
+1. Make sure you are using [Neovim][nvim] 0.4.0 or later. This plugin will not work with vanilla [VIM][vim].
 
 2. Install Firenvim as a VIM plugin as you would any other, then run the built in post-install hook script.
 
@@ -50,7 +50,7 @@ Before installing anything, please read [SECURITY.md](SECURITY.md) and make sure
 
 ### Requirements
 
-Installing from source requires nodejs, npm and neovim v.>=0.4
+Installing from source requires NodeJS, `npm`, and Neovim >= 0.4.
 
 ### Cross-browser steps
 
@@ -87,7 +87,7 @@ Firenvim currently requires the following permissions for the following reasons:
 
 ## Configuring the browser addon behavior
 
-Firenvim is configured by creating a variable named `g:firenvim_config` in your init.vim. This variable is a dictionnary containing the key "localSettings". `g:firenvim_config["localSettings"]` is a dictionnary the keys of which have to be a javascript pattern matching a url and the values of which are dictionnaries containing settings that apply for all urls matched by the javascript pattern. When multiple patterns match a same URL, the pattern with the highest "priority" value is used.
+Firenvim is configured by creating a variable named `g:firenvim_config` in your init.vim. This variable is a dictionary containing the key "localSettings". `g:firenvim_config["localSettings"]` is a dictionary the keys of which have to be a Javascript pattern matching a URL and the values of which are dictionaries containing settings that apply for all URLs matched by the Javascript pattern. When multiple patterns match a same URL, the pattern with the highest "priority" value is used.
 
 Here's an example `g:firenvim_config` that matches the default configuration:
 ```
@@ -100,7 +100,7 @@ let g:firenvim_config = {
     \ }
 \ }
 ```
-This means that for all urls ("`.*`"), textareas will be turned into firenvim instances. Here's an example that disables firenvim everywhere but enables it on github:
+This means that for all URLs ("`.*`"), textareas will be turned into Firenvim instances. Here's an example that disables Firenvim everywhere but enables it on GitHub:
 ```vimscript
 let g:firenvim_config = {
     \ 'localSettings': {
@@ -117,9 +117,9 @@ let g:firenvim_config = {
 ```
 Note that it is not necessary to specify the `priority` key because it defaults to 1, except for the `.*` pattern, which has a priority of 0.
 
-## Configuring neovim's behavior
+## Configuring Neovim's behavior
 
-You can detect when firenvim connects to neovim with the following code:
+You can detect when Firenvim connects to Neovim with the following code:
 ```
 function! OnUIEnter(event)
     let l:ui = nvim_get_chan_info(a:event.chan)
@@ -132,16 +132,16 @@ endfunction
 autocmd UIEnter * call OnUIEnter(deepcopy(v:event))
 ```
 
-Similarly, you can detect when firenvim disconnects from a neovim instance with the `UILeave` autocommand.
+Similarly, you can detect when Firenvim disconnects from a Neovim instance with the `UILeave` autocommand.
 
-If you want to use different settings depending on the textarea you're currently editing, you can use autocommands to do that too. All buffers are named like this: `domainname_page_selector.txt` (see the [toFileName function](src/utils/utils.ts)). This means that you can for example set the file type to markdown for all github buffers:
+If you want to use different settings depending on the textarea you're currently editing, you can use autocommands to do that too. All buffers are named like this: `domainname_page_selector.txt` (see the [toFileName function](src/utils/utils.ts)). This means that you can for example set the file type to markdown for all GitHub buffers:
 ```
 au BufEnter github.com_*.txt set filetype=markdown
 ```
 
 # Drawbacks
 
-The main issue with Firenvim is that some keybindings (e.g. `<C-w>`) are not overridable. I circumvent this issue by running a [patched](https://github.com/glacambre/firefox-patches) version of firefox.
+The main issue with Firenvim is that some keybindings (e.g. `<C-w>`) are not overridable. I circumvent this issue by running a [patched](https://github.com/glacambre/firefox-patches) version of Firefox.
 
 # You might also like
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,37 @@ Before installing anything, please read [SECURITY.md](SECURITY.md) and make sure
 
 ## Pre-built
 
-First, make sure you are using neovim 0.4.0 or later.
+1. Make make sure you are using [Neovim][nvim] 0.4.0 or later. This plugin will not work with vanilla [VIM][vim].
 
-Then, install Firenvim as a neovim plugin ([using](https://github.com/junegunn/vim-plug) [your](https://github.com/Shougo/dein.vim) [favourite](https://github.com/tpope/vim-pathogen) [plugin](https://github.com/k-takata/minpac) [manager](https://github.com/VundleVim/Vundle.vim)) and after that, run the following command in your shell: `nvim --headless -c "call firenvim#install(0)" -c "quit"`.
+2. Install Firenvim as a VIM plugin as you would any other, then run the built in post-install hook script.
 
-The final step is to install Firenvim in your browser from [mozilla's store](https://addons.mozilla.org/en-US/firefox/addon/firenvim/) or [google's](https://chrome.google.com/webstore/detail/firenvim/egpjdkipkomnmjhjmdamaniclmdlobbo).
+    * [vim-plug](https://github.com/junegunn/vim-plug)
+
+        ```vim
+        Plug 'glacambre/firenvim', { 'do': function('firenvim#install') }
+        ```
+
+    * [dein](https://github.com/Shougo/dein.vim)
+
+        ```vim
+        call dein#add('glacambre/firenvim', { 'hook_post_update': function('firenvim#install') })
+        ```
+
+    * [minpac](https://github.com/k-takata/minpac)
+
+        ```vim
+        call minpac#add('glacambre/firenvim', { 'do': function('firenvim#install') })
+        ```
+
+    * [pathogen](https://github.com/tpope/vim-pathogen), [vundle](https://github.com/VundleVim/Vundle.vim), others
+
+        Install the plugin as you usually would, then run this shell command:
+
+        ```sh
+        $ nvim --headless -c "call firenvim#install(0)" -c "quit"`.
+        ```
+
+3. Finally install Firenvim in your browser from [Mozilla's store](https://addons.mozilla.org/en-US/firefox/addon/firenvim/) or [Google's](https://chrome.google.com/webstore/detail/firenvim/egpjdkipkomnmjhjmdamaniclmdlobbo).
 
 ## From source
 
@@ -123,3 +149,6 @@ The main issue with Firenvim is that some keybindings (e.g. `<C-w>`) are not ove
 - [GhostText](https://github.com/GhostText/GhostText), lets you edit text areas in your editor with a single click. Requires installing a plugin in your editor too. Features live updates!
 - [Textern](https://github.com/jlebon/textern), a Firefox addon that lets you edit text areas in your editor without requiring you to install a plugin in your editor.
 - [withExEditor](https://github.com/asamuzaK/withExEditor), same thing as Textern, except you can also edit/view a page's source with your editor.
+
+ [nvim]: https://neovim.io
+ [vim]: https://www.vim.org


### PR DESCRIPTION
Man (but not all) plugin managers have hook systems for running post-install functions. These not only reduce the number of steps the user has to take the first time but make setting up on other systems easier since they don't have to come back here to find the install command every time, their plugin manager will take care of it any time they install to a new system.

This PR adds instructions for using the ones I know about, and also cleans up the README in other ways.