### PR TITLE
Add CI job that validates and lints vimscript

### DIFF
--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -1,0 +1,22 @@
+name: Vint
+
+on: [push, pull_request]
+
+jobs:
+  vint:
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Setup dependencies
+      run: pip install vim-vint
+    - name: Run Vimscript Linter
+      run: vint .

--- a/.vintrc.yaml
+++ b/.vintrc.yaml
@@ -1,0 +1,5 @@
+cmdargs:
+  severity: style_problem
+  color: true
+  env:
+    neovim: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firenvim [![Build Status](https://travis-ci.org/glacambre/firenvim.svg?branch=master)](https://travis-ci.org/glacambre/firenvim) [![Build status](https://ci.appveyor.com/api/projects/status/kboak3f5kl9hkgf4/branch/master?svg=true)](https://ci.appveyor.com/project/glacambre/firenvim/branch/master) [![Total alerts](https://img.shields.io/lgtm/alerts/g/glacambre/firenvim.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/glacambre/firenvim/alerts/)
+# Firenvim [![Build Status](https://travis-ci.org/glacambre/firenvim.svg?branch=master)](https://travis-ci.org/glacambre/firenvim) [![Build status](https://ci.appveyor.com/api/projects/status/kboak3f5kl9hkgf4/branch/master?svg=true)](https://ci.appveyor.com/project/glacambre/firenvim/branch/master) [![Total alerts](https://img.shields.io/lgtm/alerts/g/glacambre/firenvim.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/glacambre/firenvim/alerts/) [![Vint](https://github.com/glacambre/firenvim/workflows/Vint/badge.svg)](https://github.com/glacambre/firenvim/actions?workflow=Vint)
 
 Turn your browser into a Neovim client.
 

--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -2,9 +2,9 @@ let s:firenvim_done = 0
 let s:script_dir = expand('<sfile>:p:h:h')
 
 " Simple helper to build the right path depending on the platform.
-function! s:build_path(list)
-        let l:path_separator = "/"
-        if has("win32")
+function! s:build_path(list) abort
+        let l:path_separator = '/'
+        if has('win32')
                 let l:path_separator = "\\"
         endif
         return join(a:list, l:path_separator)
@@ -16,48 +16,48 @@ endfunction
 " - Bind itself to a TCP port
 " - Write the security token + tcp port number to stdout()
 " - Take care of forwarding messages received on the TCP port to neovim
-function! firenvim#run()
+function! firenvim#run() abort
         " Write messages to stdout according to the format expected by
         " Firefox's native messaging protocol
-        function! WriteStdout(id, data)
+        function! WriteStdout(id, data) abort
                 " The native messaging protocol expects the message's length
                 " to precede the message. It has to use native endianness. We
                 " assume big endian.
                 let l:len = strlen(a:data)
-                let l:lenstr = luaeval("string.char(bit.band(" . l:len . ", 255))"
-                                        \. ".. string.char(bit.band(bit.rshift(" . l:len . ", 8), 255))"
-                                        \. ".. string.char(bit.band(bit.rshift(" . l:len . ", 16), 255))"
-                                        \. ".. string.char(bit.band(bit.rshift(" . l:len . ", 24), 255))")["_VAL"]
+                let l:lenstr = luaeval('string.char(bit.band(' . l:len . ', 255))'
+                                        \. '.. string.char(bit.band(bit.rshift(' . l:len . ', 8), 255))'
+                                        \. '.. string.char(bit.band(bit.rshift(' . l:len . ', 16), 255))'
+                                        \. '.. string.char(bit.band(bit.rshift(' . l:len . ', 24), 255))')['_VAL']
                 call chansend(a:id, [join(l:lenstr) . a:data])
         endfunction
-        let s:accumulated_data = ""
-        function! OnStdin(id, data, event)
+        let s:accumulated_data = ''
+        function! OnStdin(id, data, event) abort
                 if s:firenvim_done
                         return
                 endif
                 let l:data = s:accumulated_data . a:data[0]
                 try
-                        let l:params = json_decode(matchstr(l:data[4:], "{[^}]*}"))
+                        let l:params = json_decode(matchstr(l:data[4:], '{[^}]*}'))
                 catch
                         let s:accumulated_data = l:data
                         return
                 endtry
                 let s:firenvim_done = v:true
 
-                let l:package_json = s:build_path([s:script_dir, "package.json"])
-                let l:version = json_decode(join(readfile(l:package_json), "\n"))["version"]
-                let l:result = { "version": l:version }
+                let l:package_json = s:build_path([s:script_dir, 'package.json'])
+                let l:version = json_decode(join(readfile(l:package_json), "\n"))['version']
+                let l:result = { 'version': l:version }
 
-                if exists("g:firenvim_config")
-                        let l:result["settings"] = g:firenvim_config
+                if exists('g:firenvim_config')
+                        let l:result['settings'] = g:firenvim_config
                 endif
 
-                if has_key(l:params, "newInstance") && l:params["newInstance"]
+                if has_key(l:params, 'newInstance') && l:params['newInstance']
                         let l:port = luaeval("require('firenvim').start_server('" .
-                                                \ l:params["password"] . "', '" .
-                                                \ l:params["origin"] .
+                                                \ l:params['password'] . "', '" .
+                                                \ l:params['origin'] .
                                                 \ "')")
-                        let l:result["port"] = l:port
+                        let l:result['port'] = l:port
                 endif
 
                 call WriteStdout(a:id, json_encode(result))
@@ -66,22 +66,22 @@ function! firenvim#run()
         let l:chanid = stdioopen({ 'on_stdin': 'OnStdin' })
 endfunction
 
-function! s:get_executable_name()
-        if has("win32")
-                return "firenvim.bat"
+function! s:get_executable_name() abort
+        if has('win32')
+                return 'firenvim.bat'
         endif
-        return "firenvim"
+        return 'firenvim'
 endfunction
 
-function! s:get_data_dir_path()
+function! s:get_data_dir_path() abort
         let l:xdg_data_home = $XDG_DATA_HOME
-        if l:xdg_data_home == ""
-                let l:xdg_data_home = fnamemodify(stdpath("data"), ":h")
+        if l:xdg_data_home ==# ''
+                let l:xdg_data_home = fnamemodify(stdpath('data'), ':h')
         endif
-        return s:build_path([l:xdg_data_home, "firenvim"])
+        return s:build_path([l:xdg_data_home, 'firenvim'])
 endfunction
 
-function! s:firefox_config_exists()
+function! s:firefox_config_exists() abort
         let l:p = [$HOME, '.mozilla']
         if has('mac')
                 let l:p = [$HOME, 'Library', 'Application Support', 'Mozilla']
@@ -91,7 +91,7 @@ function! s:firefox_config_exists()
         return isdirectory(s:build_path(l:p))
 endfunction
 
-function! s:get_firefox_manifest_dir_path()
+function! s:get_firefox_manifest_dir_path() abort
         if has('mac')
                 return s:build_path([$HOME, 'Library', 'Application Support', 'Mozilla', 'NativeMessagingHosts'])
         elseif has('win32')
@@ -100,7 +100,7 @@ function! s:get_firefox_manifest_dir_path()
         return s:build_path([$HOME, '.mozilla', 'native-messaging-hosts'])
 endfunction
 
-function! s:chrome_config_exists()
+function! s:chrome_config_exists() abort
         let l:p = [$HOME, '.config', 'google-chrome']
         if has('mac')
                 let l:p = [$HOME, 'Library', 'Application Support', 'Google', 'Chrome']
@@ -110,7 +110,7 @@ function! s:chrome_config_exists()
         return isdirectory(s:build_path(l:p))
 endfunction
 
-function! s:get_chrome_manifest_dir_path()
+function! s:get_chrome_manifest_dir_path() abort
         if has('mac')
                 return s:build_path([$HOME, 'Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts'])
         elseif has('win32')
@@ -119,7 +119,7 @@ function! s:get_chrome_manifest_dir_path()
         return s:build_path([$HOME, '.config', 'google-chrome', 'NativeMessagingHosts'])
 endfunction
 
-function! s:chromium_config_exists()
+function! s:chromium_config_exists() abort
         let l:p = [$HOME, '.config', 'chromium']
         if has('mac')
                 let l:p = [$HOME, 'Library', 'Application Support', 'Chromium']
@@ -129,7 +129,7 @@ function! s:chromium_config_exists()
         return isdirectory(s:build_path(l:p))
 endfunction
 
-function! s:get_chromium_manifest_dir_path()
+function! s:get_chromium_manifest_dir_path() abort
         if has('mac')
                 return s:build_path([$HOME, 'Library', 'Application Support', 'Chromium', 'NativeMessagingHosts'])
         elseif has('win32')
@@ -138,14 +138,14 @@ function! s:get_chromium_manifest_dir_path()
         return s:build_path([$HOME, '.config', 'chromium', 'NativeMessagingHosts'])
 endfunction
 
-function! s:get_progpath()
+function! s:get_progpath() abort
         let l:result = v:progpath
-        if $APPIMAGE != ""
+        if $APPIMAGE !=# ''
                 " v:progpath is different every time you run neovim appimages
                 let l:result = $APPIMAGE
         endif
         if match(l:result, '^/usr/local/Cellar/') == 0
-                let l:warning = "Warning: homebrew path detected. "
+                let l:warning = 'Warning: homebrew path detected. '
                 " On OSX, if v:progpath points to homebrew's cellar, it's
                 " going to be a version-specific path that will break when
                 " users update neovim.
@@ -155,29 +155,29 @@ function! s:get_progpath()
                         let l:warning = l:warning . "Using '" . l:constant_path . 
                                                 \ "' instead of '" . v:progpath
                 else
-                        let l:warning = l:warning . "Firenvim may break next time you update neovim."
+                        let l:warning = l:warning . 'Firenvim may break next time you update neovim.'
                 endif
                 echo l:warning
         endif
         return l:result
 endfunction
 
-function! s:get_executable_content(data_dir, prolog)
-        if has("win32")
+function! s:get_executable_content(data_dir, prolog) abort
+        if has('win32')
                 return  "@echo off\r\n" .
                                         \ "cd \"" . a:data_dir . "\"\r\n" .
                                         \ a:prolog . "\r\n" .
                                         \ "\"" . s:get_progpath() . "\" --headless -c \"call firenvim#run()\"\r\n"
         endif
         return "#!/bin/sh\n" .
-                                \ "cd " . a:data_dir . "\n" .
+                                \ 'cd ' . a:data_dir . "\n" .
                                 \ "unset NVIM_LISTEN_ADDRESS\n" .
                                 \ 'export PATH="$PATH:' . $PATH . "\"\n" .
                                 \ a:prolog . "\n" .
                                 \ "exec '" . s:get_progpath() . "' --headless -c 'call firenvim#run()'\n"
 endfunction
 
-function! s:get_manifest_beginning(execute_nvim_path)
+function! s:get_manifest_beginning(execute_nvim_path) abort
         return '{
                                 \ "name": "firenvim",
                                 \ "description": "Turn Firefox into a Neovim client.",
@@ -186,7 +186,7 @@ function! s:get_manifest_beginning(execute_nvim_path)
                                 \'
 endfunction
 
-function! s:get_chrome_manifest(execute_nvim_path)
+function! s:get_chrome_manifest(execute_nvim_path) abort
         return s:get_manifest_beginning(a:execute_nvim_path) .
                                 \' "allowed_origins": [
                                 \ "chrome-extension://egpjdkipkomnmjhjmdamaniclmdlobbo/"
@@ -194,14 +194,14 @@ function! s:get_chrome_manifest(execute_nvim_path)
                                 \}'
 endfunction
 
-function! s:get_firefox_manifest(execute_nvim_path)
+function! s:get_firefox_manifest(execute_nvim_path) abort
         return s:get_manifest_beginning(a:execute_nvim_path) .
                                 \' "allowed_extensions": ["firenvim@lacamb.re"]
                                 \}'
 endfunction
 
-function! s:key_to_ps1_str(key, manifest_path)
-        let l:ps1_content = ""
+function! s:key_to_ps1_str(key, manifest_path) abort
+        let l:ps1_content = ''
         let l:key_arr = split(a:key, '\')
         let l:i = 0
         for l:i in range(2, len(l:key_arr) - 1)
@@ -229,14 +229,14 @@ endfunction
 "      force install for every browser.
 " a:2: A prologue that should be inserted in the shell/batch script and
 "      executed before neovim is ran.
-function! firenvim#install(...)
-        if !has("nvim-0.4.0")
-                echoerr "Error: nvim version >= 0.4.0 required. Aborting."
+function! firenvim#install(...) abort
+        if !has('nvim-0.4.0')
+                echoerr 'Error: nvim version >= 0.4.0 required. Aborting.'
                 return
         endif
 
         let l:force_install = 0
-        let l:script_prolog = ""
+        let l:script_prolog = ''
         if a:0 > 0
                 let l:force_install = a:1
                 if a:0 > 1
@@ -250,73 +250,73 @@ function! firenvim#install(...)
         " Write said script to said path
         let l:execute_nvim = s:get_executable_content(l:data_dir, l:script_prolog)
 
-        call mkdir(l:data_dir, "p", 0700)
+        call mkdir(l:data_dir, 'p', 0700)
         call writefile(split(l:execute_nvim, "\n"), l:execute_nvim_path)
-        call setfperm(l:execute_nvim_path, "rwx------")
+        call setfperm(l:execute_nvim_path, 'rwx------')
 
         let l:browsers = {
-                                \"firefox": {
-                                \ "has_config": s:firefox_config_exists(),
-                                \ "manifest_content": function('s:get_firefox_manifest'),
-                                \ "manifest_dir_path": function('s:get_firefox_manifest_dir_path'),
-                                \ "registry_key": 'HKCU:\Software\Mozilla\NativeMessagingHosts\firenvim',
+                                \'firefox': {
+                                \ 'has_config': s:firefox_config_exists(),
+                                \ 'manifest_content': function('s:get_firefox_manifest'),
+                                \ 'manifest_dir_path': function('s:get_firefox_manifest_dir_path'),
+                                \ 'registry_key': 'HKCU:\Software\Mozilla\NativeMessagingHosts\firenvim',
                                 \},
-                                \"chrome": {
-                                \ "has_config": s:chrome_config_exists(),
-                                \ "manifest_content": function('s:get_chrome_manifest'),
-                                \ "manifest_dir_path": function('s:get_chrome_manifest_dir_path'),
-                                \ "registry_key": 'HKCU:\Software\Google\Chrome\NativeMessagingHosts\firenvim',
+                                \'chrome': {
+                                \ 'has_config': s:chrome_config_exists(),
+                                \ 'manifest_content': function('s:get_chrome_manifest'),
+                                \ 'manifest_dir_path': function('s:get_chrome_manifest_dir_path'),
+                                \ 'registry_key': 'HKCU:\Software\Google\Chrome\NativeMessagingHosts\firenvim',
                                 \},
-                                \"chromium": {
-                                \ "has_config": s:chromium_config_exists(),
-                                \ "manifest_content": function('s:get_chrome_manifest'),
-                                \ "manifest_dir_path": function('s:get_chromium_manifest_dir_path'),
-                                \ "registry_key": 'HKCU:\Software\Chromium\NativeMessagingHosts\firenvim',
+                                \'chromium': {
+                                \ 'has_config': s:chromium_config_exists(),
+                                \ 'manifest_content': function('s:get_chrome_manifest'),
+                                \ 'manifest_dir_path': function('s:get_chromium_manifest_dir_path'),
+                                \ 'registry_key': 'HKCU:\Software\Chromium\NativeMessagingHosts\firenvim',
                                 \},
                                 \}
 
-        let l:powershell_script = ""
-        for l:name in ["firefox", "chrome", "chromium"]
+        let l:powershell_script = ''
+        for l:name in ['firefox', 'chrome', 'chromium']
                 let l:cur_browser = l:browsers[l:name]
-                if !l:cur_browser["has_config"] && !l:force_install
-                        echo "No config detected for " . l:name . ". Skipping."
+                if !l:cur_browser['has_config'] && !l:force_install
+                        echo 'No config detected for ' . l:name . '. Skipping.'
                         continue
                 endif
 
-                let l:manifest_content = l:cur_browser["manifest_content"](l:execute_nvim_path)
-                let l:manifest_dir_path = l:cur_browser["manifest_dir_path"]()
-                let l:manifest_path = s:build_path([l:manifest_dir_path, "firenvim.json"])
+                let l:manifest_content = l:cur_browser['manifest_content'](l:execute_nvim_path)
+                let l:manifest_dir_path = l:cur_browser['manifest_dir_path']()
+                let l:manifest_path = s:build_path([l:manifest_dir_path, 'firenvim.json'])
                 
                 if has('win32')
-                        let l:manifest_path = s:build_path([l:manifest_dir_path, "firenvim-" . l:name . ".json"])
+                        let l:manifest_path = s:build_path([l:manifest_dir_path, 'firenvim-' . l:name . '.json'])
                 endif
 
                 if has('win32')
-                        let l:manifest_path = s:build_path([l:manifest_dir_path, "firenvim-" . l:name . ".json"])
+                        let l:manifest_path = s:build_path([l:manifest_dir_path, 'firenvim-' . l:name . '.json'])
                 endif
 
-                call mkdir(l:manifest_dir_path, "p", 0700)
+                call mkdir(l:manifest_dir_path, 'p', 0700)
                 call writefile([l:manifest_content], l:manifest_path)
-                call setfperm(l:manifest_path, "rw-------")
+                call setfperm(l:manifest_path, 'rw-------')
 
-                echo "Installed native manifest for " . l:name . "."
+                echo 'Installed native manifest for ' . l:name . '.'
 
                 if has('win32')
                         " On windows, also create a registry key. We
                         " do this by writing a powershell script to a
                         " file and executing it.
-                        let l:ps1_content = s:key_to_ps1_str(l:cur_browser["registry_key"],
+                        let l:ps1_content = s:key_to_ps1_str(l:cur_browser['registry_key'],
                                                 \ l:manifest_path)
-                        let l:ps1_path = s:build_path([l:manifest_dir_path, l:name . ".ps1"])
-                        echo "Creating registry key for " . l:name . ". This may take a while. Script: " . l:ps1_path
+                        let l:ps1_path = s:build_path([l:manifest_dir_path, l:name . '.ps1'])
+                        echo 'Creating registry key for ' . l:name . '. This may take a while. Script: ' . l:ps1_path
                         call writefile(split(l:ps1_content, "\n"), l:ps1_path)
-                        call setfperm(l:ps1_path, "rwx------")
+                        call setfperm(l:ps1_path, 'rwx------')
                         let o = system(['powershell', '-Command', '-'], readfile(l:ps1_path))
                         if v:shell_error
                           echo o
                         endif
 
-                        echo "Created registry key for " . l:name . "."
+                        echo 'Created registry key for ' . l:name . '.'
                 endif
         endfor
 endfunction


### PR DESCRIPTION
This PR does three things:

1. Configures [`vint`](https://github.com/Kuniwak/vint) so you can run it locally on this project (`vint .` from the root)
2. Fixes all the warnings about bad vimscript practices that it turns up
3. Adds a CI job using GitHub Actions that will run the linter on pull requests.

For the latter to work you will need to [signup for Actions on your account](https://github.com/features/actions/signup/?account=glacambre). Additionally after signing up and enabling it for this repository please note that the CI job will not start running until after this PR is merged because a workflow configuration has to exist in `master` before it considers running it on PRs. You can see the CI job in action [on my fork](https://github.com/alerque/firenvim/actions) where I tested it.

Thanks for the great plugin, I'm really enjoying using Neovim in Firefox (including to write this PR :monkey_face:).