### PR TITLE
Fix install command in README, also simplify it

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Before installing anything please read [SECURITY.md](SECURITY.md) and make sure 
         Install the plugin as you usually would, then run this shell command:
 
         ```sh
-        $ nvim --headless -c "call firenvim#install(0)" -c "quit"`.
+        $ nvim --headless "+call firenvim#install(0) | q"
         ```
 
 3. Finally install Firenvim in your browser from [Mozilla's store](https://addons.mozilla.org/en-US/firefox/addon/firenvim/) or [Google's](https://chrome.google.com/webstore/detail/firenvim/egpjdkipkomnmjhjmdamaniclmdlobbo).


### PR DESCRIPTION
It looks like the stray '\`.' on the end of this line was my fault and came from editing it out of inline Markdown. Sorry about that.

While I was at it I used a slightly more robust command that will quit nvim if the command succeeds but show more messages and wait for the user if some kinds of errors happen.