### PR TITLE
Fix lgtm errors

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -15,7 +15,7 @@
  * content scripts. It rarely acts on its own.
  */
 import * as browser from "webextension-polyfill";
-import { getIconImageData, IconKind, isFirefox } from "./utils/utils";
+import { getIconImageData, IconKind } from "./utils/utils";
 
 // We can't use the sessions.setTabValue/getTabValue apis firefox has because
 // chrome doesn't support them. Instead, we create a map of tabid => {} kept in

--- a/src/nvimproc/Neovim.ts
+++ b/src/nvimproc/Neovim.ts
@@ -1,5 +1,4 @@
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 import { page } from "../page/proxy";
 import { onRedraw } from "../render/Redraw";
 import { Stdin } from "./Stdin";

--- a/src/nvimproc/Stdin.ts
+++ b/src/nvimproc/Stdin.ts
@@ -1,6 +1,5 @@
 import * as msgpack from "msgpack-lite";
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 
 export class Stdin {
 

--- a/src/nvimproc/Stdout.ts
+++ b/src/nvimproc/Stdout.ts
@@ -1,6 +1,5 @@
 import * as msgpack from "msgpack-lite";
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 
 export class Stdout {
     private listeners = new Map<string, Array<(...args: any[]) => any>>();

--- a/src/render/Cell.ts
+++ b/src/render/Cell.ts
@@ -1,4 +1,4 @@
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 import { toHighlightClassName } from "../utils/CSSUtils";
 
 export class Cell {

--- a/src/render/Cursor.ts
+++ b/src/render/Cursor.ts
@@ -1,5 +1,4 @@
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 
 export class Cursor {
     constructor(public x: number, public y: number) {}

--- a/src/render/Grid.ts
+++ b/src/render/Grid.ts
@@ -1,5 +1,4 @@
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 import { Cursor } from "./Cursor";
 import { Row } from "./Row";
 

--- a/src/render/Redraw.ts
+++ b/src/render/Redraw.ts
@@ -1,5 +1,4 @@
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 import { page } from "../page/proxy";
 import { guifontsToCSS, toCss, toHexCss } from "../utils/CSSUtils";
 import { getCharSize, getGridSize } from "../utils/utils";

--- a/src/render/Row.ts
+++ b/src/render/Row.ts
@@ -1,5 +1,4 @@
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 import { Cell } from "./Cell";
 
 export class Row {

--- a/src/utils/CSSUtils.ts
+++ b/src/utils/CSSUtils.ts
@@ -1,5 +1,4 @@
-// lgtm[js/unused-local-variable]
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 
 // Parses a guifont declaration as described in `:h E244`
 export function parseGuifont(guifont: string) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import * as browser from "webextension-polyfill";
+import * as browser from "webextension-polyfill"; //lgtm [js/unused-local-variable]
 
 let curBrowser = "firefox";
 if (window.browser === undefined) {
@@ -89,7 +89,7 @@ export function getIconImageData(kind: IconKind, dimensions = "32x32") {
         transformations[kind](id.data);
         resolve(id);
     }));
-    img.src = "firenvim.svg";
+    img.src = svgpath;
     return result;
 }
 


### PR DESCRIPTION
Fixing the two legit ones and ignoring the rest (we want to keep the
`import browser from webextension-polyfill` lines because they'll result
in less surprises if we add code that relies on `browser` behaving the
same way in all browsers).