### PR TITLE
Set `g:firenvim_mode` variable when starting nvim.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,16 @@ au TextChangedI * ++nested call Delay_My_Write()
 
 ## Configuring Neovim's behavior
 
-You can detect when Firenvim connects to Neovim with the following code:
+When it starts Neovim, Firenvim sets the variable `g:started_by_firenvim` which you can check to run different code in your init.vim. For example:
+```
+if exists('g:started_by_firenvim')
+  set laststatus=0
+else
+  set laststatus=2
+endif
+```
+
+Alternatively, you can detect Firenvim using the `UIEnter` autocmd event:
 ```
 function! OnUIEnter(event)
     let l:ui = nvim_get_chan_info(a:event.chan)

--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -174,7 +174,7 @@ function! s:get_executable_content(data_dir, prolog) abort
                                 \ "unset NVIM_LISTEN_ADDRESS\n" .
                                 \ 'export PATH="$PATH:' . $PATH . "\"\n" .
                                 \ a:prolog . "\n" .
-                                \ "exec '" . s:get_progpath() . "' --headless -c 'call firenvim#run()'\n"
+                                \ "exec '" . s:get_progpath() . "' --headless --cmd 'let g:started_by_firenvim = v:true' -c 'call firenvim#run()'\n"
 endfunction
 
 function! s:get_manifest_beginning(execute_nvim_path) abort


### PR DESCRIPTION
This enables running code during initialization, when the vimrc is read,
before the OnUIEnter event fires.
Fixes #205