### PR TITLE
Make firenvim less secure

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Webextensions are made of [several kinds of processes](https://developer.mozilla
 
 These scripts have different permissions. For example, the background script can start new processes on your computer but cannot access the content of your tabs. The content script has the opposite permissions. The frame script is just a kind of content script that executes in a frame.
 
-When you launch your browser (or install Firenvim), the background script starts a new NeoVim process and writes a randomly-generated 32-bit password and the hash of the webextension to its stdin. The NeoVim process binds itself to a random TCP port and sends the port number to the background script by writing to stdout.
+When you launch your browser (or install Firenvim), the background script starts a new NeoVim process and writes a randomly-generated 32-bit password to its stdin. The NeoVim process binds itself to a random TCP port and sends the port number to the background script by writing to stdout.
 
 When you open a new tab, the content script adds event listeners to text areas. When you focus one of the text areas the content script is listening to, it creates a new frame and places it on top of the text area.
 
@@ -18,7 +18,6 @@ When it is created, the frame script asks the background script for the port and
 When the NeoVim process notices a new connection, it makes sure that:
 - The password is in the handshake.
 - The handshake really is a websocket handshake.
-- The websocket has been created by a web-extension the hash of which matches the one it was given on startup.
 
 If any of these conditions isn't met, the NeoVim process closes its socket and port and then shuts itself down.
 
@@ -30,7 +29,7 @@ After a successful websocket handshake, the frame script and neovim process comm
 
 A malicious page could create an infinite amount of textareas and focus them all ; this could result in PID and/or port and/or memory exhaustion. A simple way to prevent this kind of attack is to add a limit to the amount of allowed concurrent processes. This limit isn't implemented yet but it is planned.
 
-A malicious page could try to connect to the NeoVim process started by the background script with its own-websocket. However, pages can't forge the "Origin" header of websockets handshakes or of AJAX requests (see [this page](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name)) and thus wouldn't be able to connect.
+A malicious page could try to connect to the NeoVim process started by the background script with its own-websocket. However, it would have to guess the password the NeoVim process was started with in order to be able to send commands to NeoVim.
 
 A malicious page could try to send key events to the neovim frame. However, only the script inside the frame listens for key events and a page can't send key events to a child frame (and even then, the frame script makes sure that [events are trusted](https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted)).
 
@@ -48,7 +47,7 @@ The neovim process binds itself to 127.0.0.1, so malicious actors on your LAN sh
 
 ### Malicious software on your computer
 
-Malicious software on your computer could try to connect to the neovim process but they would have to find out what port, password and extension hash are needed. This information lives either in firefox or neovim's RAM. If you're running malicious software that can read your RAM, you probably have bigger problems than a webextension that lets you use neovim from your browser.
+Malicious software on your computer could try to connect to the neovim process but they would have to find out what port and password. This information lives either in firefox or neovim's RAM. If you're running malicious software that can read your RAM, you probably have bigger problems than a webextension that lets you use neovim from your browser.
 
 ## Sandboxing Firenvim
 

--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -68,8 +68,7 @@ function! firenvim#run() abort
 
                 if has_key(l:params, 'newInstance') && l:params['newInstance']
                         let l:port = luaeval("require('firenvim').start_server('" .
-                                                \ l:params['password'] . "', '" .
-                                                \ l:params['origin'] .
+                                                \ l:params['password'] .
                                                 \ "')")
                         let l:result['port'] = l:port
                 endif

--- a/lua/firenvim.lua
+++ b/lua/firenvim.lua
@@ -11,7 +11,7 @@ local function close_server(server)
         end)
 end
 
-local function firenvim_start_server(token, origin)
+local function firenvim_start_server(token)
         local server = vim.loop.new_tcp()
         server:nodelay(true)
         server:bind('127.0.0.1', 0)
@@ -39,10 +39,8 @@ local function firenvim_start_server(token, origin)
                                         -- because it isn't complete yet
                                         return
                                 end
-                                local origin_pattern = "^" .. string.gsub(origin, "-", "%%-") .. "$"
                                 if not (string.match(request, "^GET /" .. token .. " HTTP/1.1\r\n$")
                                         and string.match(headers["Connection"] or "", "Upgrade")
-                                        and string.match(headers["Origin"] or "", origin_pattern)
                                         and string.match(headers["Upgrade"] or "", "websocket"))
                                 then
                                         -- Connection didn't give us the right

--- a/src/background.ts
+++ b/src/background.ts
@@ -185,7 +185,6 @@ function createNewInstance() {
         });
         nvim.postMessage({
             newInstance: true,
-            origin: browser.runtime.getURL("").slice(0, -1),
             password: password[0],
         });
     });


### PR DESCRIPTION
This commit removes a check ensuring that the `Origin` of a websocket
was that of the firenvim webextension which started neovim. This check
is removed because Mozilla decided to remove the `Origin` field of
websocket connections created from a webextension context (see
https://bugzilla.mozilla.org/show_bug.cgi?id=1596889 and
https://bugzilla.mozilla.org/show_bug.cgi?id=1592721).

An alternative would have been to re-create this field with the
webRequest API. However, there are two blockers: this requires a new
permission (I learned from working on Tridactyl that Firefox is pretty
bad at updating extensions that require new permissions) and Chrome is
going to remove the webRequest API anyway.

Note that firenvim should still be secure for the following reasons:
- It binds itself to a random port
- It uses a 32-bit one time password to make sure that the incomming
  connection is made from the webextension that started neovim.
- Neovim kills itself immediately if the websocket connection can't be
  authenticated.

Still, Firenvim is less secure because of this removal: theorically
speaking, a malicious webpage could get lucky and discover the right
port and password combination. Before this removal, this wouldn't have
mattered as pages can't forge the Origin of their websockets.

Closes #233.