### PR TITLE
Fix keyhandler breaking big frames

### DIFF
--- a/src/NeovimFrame.ts
+++ b/src/NeovimFrame.ts
@@ -177,9 +177,6 @@ window.addEventListener("load", async () => {
             }
         });
         keyHandler.addEventListener("keydown", (evt) => {
-            keyHandler.style.left = `0px`;
-            keyHandler.style.top = `0px`;
-
             // Special case AltRight: both AltLeft and AltRight cause keyevents
             // to have their `altKey` attribute set to true, but only AltLeft
             // events should be treated as special keys.

--- a/src/render/Grid.ts
+++ b/src/render/Grid.ts
@@ -42,7 +42,7 @@ export class Grid {
     }
 
     public get(n: number) {
-        if (n < 0 || n >= this.width) {
+        if (n < 0 || n >= this.height) {
             throw new Error(`Out of bounds access: ${n}`);
         }
         return this.rows[n];

--- a/src/render/Redraw.ts
+++ b/src/render/Redraw.ts
@@ -36,7 +36,15 @@ const redrawFuncs = {
     },
     flush: (elem: HTMLElement) => nvimHighlightStyle.innerText = toCss(highlights),
     grid_clear: (elem: HTMLElement, selector: string, [id]: [number]) => grids[id].clear(),
-    grid_cursor_goto: (elem: HTMLElement, selector: string, [id, y, x]: GotoUpdate) => grids[id].cursor_goto(x, y),
+    grid_cursor_goto: (elem: HTMLElement, selector: string, [id, y, x]: GotoUpdate) => {
+        grids[id].cursor_goto(x, y);
+        setTimeout(() => {
+            const keyHandler = document.getElementById("keyhandler");
+            const [cellWidth, cellHeight] = getCharSize(elem);
+            keyHandler.style.left = `${cellWidth * x}px`;
+            keyHandler.style.top = `${cellHeight * y}px`;
+        });
+    },
     grid_line: (elem: HTMLElement, selector: string, [id, row, col, contents]: LineUpdate) =>
     contents.reduce(({ prevCol, highlight }, content) => {
         const [chara, high = highlight, repeat = 1] = content;


### PR DESCRIPTION
On frames larger than the viewport, the keyhandler would make the frame
scroll up, which would prevent users from seeing what they're typing at
the bottom of the frame.