### PR TITLE
Set default font and default size

### DIFF
--- a/src/NeovimFrame.html
+++ b/src/NeovimFrame.html
@@ -33,7 +33,7 @@
         <style id="nvim_highlight_style"></style>
         <style id="nvim_cursor_style"></style>
         <style id="nvim_linespace"></style>
-        <style id="nvim_guifont"></style>
+        <style id="nvim_guifont">* { font-family: monospace; font-size: 9pt; }</style>
         <style id="mouse_cursor"></style>
         <script type="application/javascript" src="nvimui.js"></script>
     </head>

--- a/src/NeovimFrame.html
+++ b/src/NeovimFrame.html
@@ -8,9 +8,6 @@
                 margin: 0px;
                 padding: 0px;
                 overflow: hidden;
-                display: flex;
-                justify-content: center;
-                align-items: center;
             }
             #keyhandler {
                 height: 1px;

--- a/src/content.ts
+++ b/src/content.ts
@@ -124,6 +124,7 @@ const global = {
         // by other elements), so we use an intersection observer, which is
         // triggered every time the element becomes more or less visible.
         (new IntersectionObserver((entries, observer) => {
+            console.log(entries, observer);
             if (!elem.ownerDocument.contains(elem)
                 || (elem.offsetWidth === 0 && elem.offsetHeight === 0 && elem.getClientRects().length === 0)) {
                 functions.killEditor(selector);


### PR DESCRIPTION
This fixes issues where users would set a non-existing font which would
prevent firenvim from correctly computing the size of the frame.