### PR TITLE
Cell.ts: cache value

### DIFF
--- a/src/render/Cell.ts
+++ b/src/render/Cell.ts
@@ -4,10 +4,12 @@ import { toHighlightClassName } from "../utils/CSSUtils";
 export class Cell {
     private highlightValue: number;
     private elem: HTMLSpanElement;
+    private val: string;
 
     constructor() {
         this.elem = document.createElement("span");
-        this.elem.innerText = " ";
+        this.val = " ";
+        this.elem.innerText = this.val;
         this.elem.className = "nvim_cell";
         this.highlight = 0;
     }
@@ -31,11 +33,12 @@ export class Cell {
     }
 
     get value() {
-        return this.elem.innerText;
+        return this.val;
     }
 
     set value(v: string) {
-        this.elem.innerText = v;
+        this.val = v;
+        this.elem.innerText = this.val;
     }
 
     public clear() {


### PR DESCRIPTION
Before this commit, returning the value was done by fetching
elem.innerText. This somehow forced chrome to recompute styles
(something it apparently did not need to do with the previous scrolling
algorithm) and caused massive performance issues. Simply caching the
value is enough to fix this problem.

Closes #250