### PR TITLE
Fix firenvim breaking on big buffers

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -92,9 +92,12 @@ local function to_64_bits_str(number)
 end
 
 -- Returns a number representing the 8 first characters of the argument string
--- Returns incorrect results on numbers larger than 2^32
+-- Returns incorrect results on numbers larger than 2^48
 local function to_64_bits_number(str)
-        return bit.lshift(string.byte(str, 5), 24) +
+        return bit.lshift(string.byte(str, 2), 48) +
+                bit.lshift(string.byte(str, 3), 40) +
+                bit.lshift(string.byte(str, 4), 32) +
+                bit.lshift(string.byte(str, 5), 24) +
                 bit.lshift(string.byte(str, 6), 16) +
                 bit.lshift(string.byte(str, 7), 8) +
                 string.byte(str, 8)

--- a/tests/_common.ts
+++ b/tests/_common.ts
@@ -531,6 +531,24 @@ ${backup}
                 });
 }
 
+export async function testLargeBuffers(driver: any) {
+        await loadLocalPage(driver, "simple.html");
+        console.log("Locating textarea…");
+        const input = await driver.wait(Until.elementLocated(By.id("content-input")));
+        await driver.executeScript(`arguments[0].scrollIntoView(true);
+                                   arguments[0].value = (new Array(10000)).fill("a").join("");`, input);
+        console.log("Clicking on input…");
+        await driver.actions().click(input).perform();
+        console.log("Waiting for span to be created…");
+        const span = await driver.wait(Until.elementLocated(By.css("body > span:nth-child(2)")));
+        await driver.sleep(1000);
+        await sendKeys(driver, ":wq!".split("").concat(webdriver.Key.ENTER))
+        console.log("Waiting for span to be removed from page…");
+        await driver.wait(Until.stalenessOf(span));
+        console.log("Waiting for value update…");
+        await driver.wait(async () => (await input.getAttribute("value")) == (new Array(10000)).fill("a").join(""));
+}
+
 export async function killDriver(driver: any) {
         try {
                 await driver.close()

--- a/tests/chrome.ts
+++ b/tests/chrome.ts
@@ -17,7 +17,7 @@ import {
  testGuifont,
  testInputFocus,
  testInputFocusedAfterLeave,
- testManualNvimify,
+ testLargeBuffers,
  testModifiers,
  testMonaco,
  testNestedDynamicTextareas,
@@ -77,6 +77,7 @@ describe("Chrome", () => {
         nonHeadlessTest()("Input is focused after leaving frame", () => testInputFocusedAfterLeave(driver));
         nonHeadlessTest()("InputFocus works", () => testInputFocus(driver));
         nonHeadlessTest()("Guifont works", () => testGuifont(driver));
+        nonHeadlessTest()("Firenvim works with large buffers", () => testLargeBuffers(driver));
         nonHeadlessTest()("Firenvim works on Monaco", () => testMonaco(driver));
         nonHeadlessTest()("Firenvim works on dynamically created nested elements", () => testNestedDynamicTextareas(driver));
         nonHeadlessTest()("Firenvim works on dynamically created elements", () => testDynamicTextareas(driver));

--- a/tests/firefox.ts
+++ b/tests/firefox.ts
@@ -18,6 +18,7 @@ import {
  testGuifont,
  testInputFocus,
  testInputFocusedAfterLeave,
+ testLargeBuffers,
  testManualNvimify,
  testModifiers,
  testMonaco,
@@ -79,6 +80,7 @@ describe("Firefox", () => {
         test("Firenvim works on dynamically created elements", () => testDynamicTextareas(driver));
         test("Firenvim works on dynamically created nested elements", () => testNestedDynamicTextareas(driver));
         test("Firenvim works on Monaco", () => testMonaco(driver));
+        test("Firenvim works with large buffers", () => testLargeBuffers(driver));
         test("Guifont works", () => testGuifont(driver));
         test("InputFocus works", () => testInputFocus(driver));
         test("Input is focused after leaving frame", () => testInputFocusedAfterLeave(driver));


### PR DESCRIPTION
This was caused by websocket frames being split up in multiple TCP
frames. The solution is to make sure we don't process frames until
they're complete.

Closes #179.