### PR TITLE
Fix instructions for minpac

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,15 @@ Before installing anything please read [SECURITY.md](SECURITY.md) and make sure 
     * [minpac](https://github.com/k-takata/minpac)
 
         ```vim
-        call minpac#add('glacambre/firenvim', { 'do': { _ -> firenvim#install(0) } })
+        call minpac#add('glacambre/firenvim', { 'type': 'opt', 'do': 'packadd firenvim | call firenvim#install(0)'})
+        ```
+
+        To load Firenvim when needed:
+
+        ```vim
+        if exists('g:started_by_firenvim')
+          packadd firenvim
+        endif
         ```
 
     * [pathogen](https://github.com/tpope/vim-pathogen), [vundle](https://github.com/VundleVim/Vundle.vim), others


### PR DESCRIPTION
Discussed:

https://github.com/k-takata/minpac/issues/95

https://github.com/glacambre/firenvim/issues/318#issuecomment-570307402

Basically, minpac doesn't load the plugin when it is installed so `firenvim#install(0)` cannot be run. This will probably never be fixed in `minpac` as it uses vim8's builtin package managing feature and loading the package at install time will require a big change.