### PR TITLE
firenvim.vim: implement nativemessenger for brave/opera/vivaldi

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -28,8 +28,5 @@ install:
   - ps: Set-Content -Path "C:\Users\appveyor\AppData\Local\nvim\init.vim" -Value "set rtp+=C:\projects\firenvim"
   - npm ci
   - npm run build
-  - ps: New-Item -Path "HKCU:\Software\Mozilla\NativeMessagingHosts"
-  - ps: New-Item -Path "HKCU:\Software\Mozilla\NativeMessagingHosts\firenvim"
-  - ps: Set-Item -Path "HKCU:\Software\Mozilla\NativeMessagingHosts\firenvim\" -Value "C:\Users\me\AppData\Local\firenvim\firenvim-firefox.json"
   - npm run install_manifests
   - npm run test firefox


### PR DESCRIPTION
These browsers previously worked if chrome was already installed on the
machine. Now they'll work without it.

Closes #180.
Closes #355.