### PR TITLE
Document supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Before installing anything please read [SECURITY.md](SECURITY.md) and make sure 
 
 ### Pre-built
 
-1. Make sure you are using [Neovim][nvim] 0.4.0 or later. This plugin will not work with vanilla [VIM][vim] or [Vimr](vimr).
+1. Make sure you are using [Neovim][nvim] 0.4.0 or later. This plugin will not work with vanilla [VIM][vim] or [Vimr][vimr].
 
 2. Check if the luabitop package is available by running `:lua bit.band(1,1)` in Neovim. If this throws an error, you will need to install it.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Firenvim [![Build Status](https://travis-ci.org/glacambre/firenvim.svg?branch=master)](https://travis-ci.org/glacambre/firenvim) [![Build status](https://ci.appveyor.com/api/projects/status/kboak3f5kl9hkgf4/branch/master?svg=true)](https://ci.appveyor.com/project/glacambre/firenvim/branch/master) [![Total alerts](https://img.shields.io/lgtm/alerts/g/glacambre/firenvim.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/glacambre/firenvim/alerts/) [![Vint](https://github.com/glacambre/firenvim/workflows/Vint/badge.svg)](https://github.com/glacambre/firenvim/actions?workflow=Vint)
 
-Turn your browser into a Neovim client.
+Turn your browser¹ into a Neovim client.
+
+¹ <sub>Firefox and Chrome are specifically supported. Other Chromium based browsers such as Brave, Vivaldi, and Opera should also work but are not specifically tested.</sub>
 
 ![Firenvim demo](firenvim.gif)
 


### PR DESCRIPTION
1. Fix link to Vimr (unsupported editor variant)
1. List supported browsers (see also #356) because the project name suggests it might be a Firefox only thing.