### PR TITLE
functions.ts: unfocus active element before trying to refocus it

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -104,12 +104,16 @@ const global = {
         // actually stop refocusing the iframe a second after it is created.
         function refocus() {
             setTimeout(() => {
+                // First, destroy current selection. Some websites use the
+                // selection to force-focus an element.
                 const sel = document.getSelection();
                 sel.removeAllRanges();
                 const range = document.createRange();
                 range.setStart(span, 0);
                 range.collapse(true);
                 sel.addRange(range);
+                // Then, attempt to "release" the focus from whatever element
+                // is currently focused.
                 window.focus();
                 document.documentElement.focus();
                 document.body.focus();

--- a/src/page/functions.ts
+++ b/src/page/functions.ts
@@ -94,6 +94,7 @@ function _refocus(span: any, iframe: any) {
     range.setStart(span, 0);
     range.collapse(true);
     sel.addRange(range);
+    (document.activeElement as any).blur();
     // On chrome, you can't refocus the iframe once the body has been focused…
     if (isFirefox()) {
         window.focus();


### PR DESCRIPTION
Unfocusing the active element works around a bug where the iframe
wouldn't be properly refocused on matrix. It's a bit weird but let's not
look a gift fix in the code.

Closes #343