### PR TITLE
Correctly detect Monaco editor in GitLab Web IDE

### DIFF
--- a/src/editors/MonacoEditor.ts
+++ b/src/editors/MonacoEditor.ts
@@ -24,7 +24,7 @@ export class MonacoEditor extends AbstractEditor {
         // Find the monaco element that holds the data
         let parent = this.elem.parentElement;
         while (!(this.elem.className.match(/monaco-editor/gi)
-                 && this.elem.getAttribute("data-uri").match("inmemory://"))) {
+                 && this.elem.getAttribute("data-uri").match("inmemory://|gitlab:"))) {
             this.elem = parent;
             parent = parent.parentElement;
         }


### PR DESCRIPTION
GitLab seems to use a sligtly modified Monaco editor in the GitLab Web IDE. With this minor change firenvim works well within GitLab Web IDE.