### PR TITLE
Fix CodeMirrorEditor for JupyterLab support

### DIFF
--- a/src/editors/CodeMirrorEditor.ts
+++ b/src/editors/CodeMirrorEditor.ts
@@ -8,7 +8,7 @@ export class CodeMirrorEditor extends AbstractEditor {
         let parent = e;
         for (let i = 0; i < 3; ++i) {
             if (parent !== undefined && parent !== null) {
-                if ((/CodeMirror/gi).test(parent.className)) {
+                if ((/(\A| )CodeMirror/gi).test(parent.className)) {
                     return true;
                 }
                 parent = parent.parentElement;


### PR DESCRIPTION
Modified the regexp used to detect the CodeMirror root element during CodeMirror detection. Now it checks to make sure the class it is looking for *starts* with CodeMirror, as opposed to just containing “CodeMirror” This prevents it from matching `jp-CodeMirrorEditor`, which is a Jupyter wrapper class that doesn’t expose the correct API. Instead it will now correctly match the CodeMirror root in JupyterLab cells.