### PR TITLE
improve: add callback as an optional argument to handle eval_js result

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -16,7 +16,7 @@ function! firenvim#get_chan() abort
         return uis[0].chan
 endfunction
 
-function! firenvim#eval_js(js) abort
+function! firenvim#eval_js(js, ...) abort
         let callback_name = get(a:, 1, '')
         call rpcnotify(firenvim#get_chan(), 'firenvim_eval_js', a:js, callback_name)
 endfunction

--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -17,7 +17,8 @@ function! firenvim#get_chan() abort
 endfunction
 
 function! firenvim#eval_js(js) abort
-        call rpcnotify(firenvim#get_chan(), 'firenvim_eval_js', a:js)
+        let callback_name = get(a:, 1, '')
+        call rpcnotify(firenvim#get_chan(), 'firenvim_eval_js', a:js, callback_name)
 endfunction
 
 " Asks the browser extension to release focus from the frame and focus the

--- a/src/nvimproc/Neovim.ts
+++ b/src/nvimproc/Neovim.ts
@@ -65,7 +65,10 @@ export async function neovim(
                     .then(() => { if (hasFocus && !document.hasFocus()) { window.focus(); } });
                 break;
             case "firenvim_eval_js":
-                page.evalInPage(args[0]);
+                const result = await page.evalInPage(args[0]);
+                if (args[1]) {
+                    request("nvim_call_function", [args[1], [JSON.stringify(result)]]);
+                }
                 break;
             case "firenvim_focus_page":
                 page.focusPage();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -25,10 +25,10 @@ export function executeInPage(code: string): Promise<any> {
     return new Promise((resolve, reject) => {
         const script = document.createElement("script");
         const eventId = (new URL(browser.runtime.getURL(""))).hostname + Math.random();
-        script.innerHTML = `((evId) => {
+        script.innerHTML = `(async (evId) => {
             try {
                 let result;
-                result = ${code};
+                result = await ${code};
                 window.dispatchEvent(new CustomEvent(evId, {
                     detail: {
                         success: true,

--- a/tests/_common.ts
+++ b/tests/_common.ts
@@ -387,7 +387,7 @@ export async function testEvalJs(driver: webdriver.WebDriver) {
         const ready = firenvimReady(driver);
         await driver.wait(Until.elementLocated(By.css("body > span:nth-child(2)")), 5000, "body > span:nth-child(2) not found");
         await ready;
-        await sendKeys(driver, `:call firenvim#eval_js('document`.split(""));
+        await sendKeys(driver, `:call firenvim#eval_js('(document`.split(""));
         // Using the <C-v> trick here because Chrome somehow replaces `.` with
         // `<`. This might have to do with locale stuff?
         await driver.actions()
@@ -403,7 +403,7 @@ export async function testEvalJs(driver: webdriver.WebDriver) {
                 .keyUp("v")
                 .keyUp(webdriver.Key.CONTROL)
                 .perform();
-        await sendKeys(driver, `046value = "Eval Works!"')`.split("")
+        await sendKeys(driver, `046value = "Eval Works!")')`.split("")
                 .concat(webdriver.Key.ENTER));
         await driver.wait(async () => (await input.getAttribute("value")) !== "", 5000, "Input value did not change");
         expect(await input.getAttribute("value")).toBe("Eval Works!");


### PR DESCRIPTION
This PR tries to provide an *optional* argument `callback_name` to the function `firenvim#eval_js`. 

The new signature of this function will be like the following:

```vim
firenvim#eval_js(code: string, callback_name?: string)
```

In this way, we can handle the result of the javascript evaluation in the vim script.

## Usages

```vim
function EvalJSCallback(result)
    echom 'result' a:result
endfunction

function EvalJS()
    let js = "location.href"
    call firenvim#eval_js(js, 'EvalJSCallback')
endfunction
```
output: `result "https://www.google.com"`

```vim
function EvalJSCallback(result)
    echom 'result' a:result
endfunction

function EvalJS()
    let js = "new Promise(resolve => fetch('https://jsonplaceholder.typicode.com/todos/1').then(response => response.json()).then(resolve))"
    call firenvim#eval_js(js, 'EvalJSCallback')
endfunction
```
output: `result {"userId":1,"id":1,"title":"delectus aut autem","completed":false}`