### PR TITLE
Adding killEditorSilently function and focus_page_and_firenvim_vimlea…

### DIFF
--- a/src/nvimproc/Neovim.ts
+++ b/src/nvimproc/Neovim.ts
@@ -85,6 +85,10 @@ export async function neovim(
             case "firenvim_vimleave":
                 page.killEditor();
                 break;
+            case "focus_page_and_firenvim_vimleave":
+                page.focusPage();
+                page.killEditorSilently();
+                break;
         }
     });
 

--- a/src/page/functions.ts
+++ b/src/page/functions.ts
@@ -118,6 +118,12 @@ export function getNeovimFrameFunctions(global: IGlobalState) {
             _focusInput(global, firenvim, conf.takeover !== "once");
             global.firenvimElems.delete(frameId);
         },
+        killEditorSilently: (frameId: number) => {
+            const firenvim = global.firenvimElems.get(frameId);
+            firenvim.detachFromPage();
+            const conf = getConf();
+            global.firenvimElems.delete(frameId);
+        },
         pressKeys: (frameId: number, keys: string[]) => {
             global.firenvimElems.get(frameId).pressKeys(keysToEvents(keys));
         },


### PR DESCRIPTION
This PR makes it able to kill nvim and focus page because normal `killEditor` function always get the focus to input.

As I'd like to use firenvim with jupyter notebook, this PR will enable us to leave jupyter cell directly from the nvim window.