### PR TITLE
Simple tinyMCE editor

### DIFF
--- a/src/editors/TinymceEditor.ts
+++ b/src/editors/TinymceEditor.ts
@@ -22,10 +22,10 @@ export class TinymceEditor extends AbstractEditor {
     // The content will usually be a condensed HTML source of the rendered text.
     // However we can set a bookmark so that cursor position can be restored later.
     getCursor () {
-        var bookmark = document.createElement('span');
-        bookmark.className = 'firenvim_bookmark'
+        const bookmark = document.createElement('span');
+        bookmark.className = 'firenvim_bookmark';
 
-        var range = window.getSelection().getRangeAt(0);
+        const range = window.getSelection().getRangeAt(0);
         range.insertNode(bookmark);
 
         return Promise.resolve([1, 0] as [number, number]);
@@ -51,14 +51,12 @@ export class TinymceEditor extends AbstractEditor {
     // The NVIM line & column make no sense as tinymce selector.
     // Instead restore the cursor to the previously set bookmark and remove the bookmark.
     setCursor (line: number, column: number) {
-        debugger;
         return executeInPage(`(${/* istanbul ignore next */ () => {
-            debugger;
-            var bookmark = document.getElementsByClassName('firenvim_bookmark')[0];
-            var range = document.createRange ();
+            const bookmark = document.getElementsByClassName('firenvim_bookmark')[0];
+            const range = document.createRange ();
             range.selectNode(bookmark);
 
-            var selection = window.getSelection();
+            const selection = window.getSelection();
             selection.removeAllRanges();
             selection.addRange(range);
 

--- a/src/editors/TinymceEditor.ts
+++ b/src/editors/TinymceEditor.ts
@@ -45,6 +45,9 @@ export class TinymceEditor extends AbstractEditor {
     }
 
     // TODO: this does not work
+    // I also tried using window.tinymce.activeEditor API, but the editor leaves in the parent window
+    // not the frame which is currently focused
+    //
     // The NVIM line & column make no sense as tinymce selector.
     // Instead restore the cursor to the previously set bookmark and remove the bookmark.
     setCursor (line: number, column: number) {

--- a/src/editors/TinymceEditor.ts
+++ b/src/editors/TinymceEditor.ts
@@ -1,0 +1,65 @@
+import { AbstractEditor } from "./AbstractEditor";
+import { executeInPage, computeSelector } from "../utils/utils";
+
+export class TinymceEditor extends AbstractEditor {
+
+    static matches (e: HTMLElement) {
+        return (e.id === 'tinymce');
+    }
+
+    private elem: HTMLElement;
+    constructor (e: HTMLElement) {
+        super();
+        this.elem = e;
+    }
+
+    getContent () {
+        const text = this.elem.innerHTML;
+        return Promise.resolve(text);
+    }
+
+    // It doesn't make a lot of sense to calculate cursor's position (if at all possible).
+    // The content will usually be a condensed HTML source of the rendered text.
+    // However we can set a bookmark so that cursor position can be restored later.
+    getCursor () {
+        var bookmark = document.createElement('span');
+        bookmark.className = 'firenvim_bookmark'
+
+        var range = window.getSelection().getRangeAt(0);
+        range.insertNode(bookmark);
+
+        return Promise.resolve([1, 0] as [number, number]);
+    }
+
+    getElement () {
+        return this.elem;
+    }
+
+    getLanguage () {
+        return Promise.resolve('html');
+    }
+
+    setContent (text: string) {
+        this.elem.innerHTML = text;
+        return Promise.resolve();
+    }
+
+    // TODO: this does not work
+    // The NVIM line & column make no sense as tinymce selector.
+    // Instead restore the cursor to the previously set bookmark and remove the bookmark.
+    setCursor (line: number, column: number) {
+        debugger;
+        return executeInPage(`(${/* istanbul ignore next */ () => {
+            debugger;
+            var bookmark = document.getElementsByClassName('firenvim_bookmark')[0];
+            var range = document.createRange ();
+            range.selectNode(bookmark);
+
+            var selection = window.getSelection();
+            selection.removeAllRanges();
+            selection.addRange(range);
+
+            return range.deleteContents();
+        }})()`);
+    }
+}

--- a/src/editors/editors.ts
+++ b/src/editors/editors.ts
@@ -3,12 +3,14 @@ import { AceEditor } from "./AceEditor";
 import { CodeMirrorEditor } from "./CodeMirrorEditor";
 import { MonacoEditor } from "./MonacoEditor";
 import { TextareaEditor } from "./TextareaEditor";
+import { TinymceEditor } from "./TinymceEditor";
 
 export function getEditor(elem: HTMLElement): AbstractEditor {
     switch (true) {
         case AceEditor.matches(elem): return new AceEditor(elem);
         case CodeMirrorEditor.matches(elem): return new CodeMirrorEditor(elem);
         case MonacoEditor.matches(elem): return new MonacoEditor(elem);
+        case TinymceEditor.matches(elem): return new TinymceEditor(elem);
         default: return new TextareaEditor(elem);
     }
 }


### PR DESCRIPTION
I'm not sure if you should merge this pull request as it is.
I couldn't however create a new branch in your repo.

I need some help to get the cursor bookmark working.
The bookmark is added.

Testing from Firefox console I can also get the cursor restored as well, but for some reason the code in setCursor does not work.

There is even a better way than using plan JS, which is to use the tinyMCE API.
However the editor lives in the main window, and is not accessible from the iframe window.
I'm mentioning it if you have some idea how to access it perhaps.