### PR TITLE
chrome dev manifest creation on mac

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -309,7 +309,9 @@ endfunction
 
 function! s:chrome_dev_config_exists() abort
         let l:p = [$HOME, '.config', 'google-chrome-unstable']
-        if !empty($XDG_CONFIG_HOME)
+        if has('mac')
+                let l:p = [$HOME, 'Library', 'Application Support', 'Google', 'Chrome Dev']
+        elseif !empty($XDG_CONFIG_HOME)
                 let l:p = [$XDG_CONFIG_HOME, 'google-chrome-unstable']
         end
         return isdirectory(s:build_path(l:p))
@@ -341,7 +343,7 @@ endfunction
 
 function! s:get_chrome_dev_manifest_dir_path() abort
         if has('mac')
-                throw 'No chrome dev on mac.'
+                return s:build_path([$HOME, 'Library', 'Application Support', 'Google', 'Chrome Dev', 'NativeMessagingHosts'])
         elseif has('win32') || s:is_wsl
                 throw 'No chrome dev on win32.'
         end


### PR DESCRIPTION
Fixes #1005.

Tested on  Version 91.0.4464.5 (Official Build) dev (x86_64). firenvim.json created in `$HOME/Library/ApplicationSupport/Google/Chrome Dev/NativeMessagingHosts`.

```json
{ "name": "firenvim", "description": "Turn Firefox into a Neovim client.", "path": "$HOME/.local/share/firenvim/firenvim", "type": "stdio", "allowed_origins": [ "chrome-extension://egpjdkipkomnmjhjmdamaniclmdlobbo/" ]}
```