### PR TITLE
Add listener for external message, so that it can be integrated.

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -402,6 +402,10 @@ updateIcon();
 /* istanbul ignore next */
 if (!isThunderbird()) {
     browser.commands.onCommand.addListener(acceptCommand);
+    browser.runtime.onMessageExternal.addListener(async (request: any, sender: any, _sendResponse: any) => {
+        const resp = await acceptCommand(request.command);
+        _sendResponse(resp);
+    });
 }
 
 async function updateIfPossible() {


### PR DESCRIPTION
Hi dear author, 

I just tried `firenvim`, it works really great in Chrome, it can even edit local files, which makes it a true GUI client for `neovim`. And I also would like to integrate it with `Surfingkeys` as people suggested here https://github.com/brookhong/Surfingkeys/issues/1064.

This PR is to make `firenvim` to listen external message and handle incoming message as commands, which has not limited to special senders. If you'd like the senders limited to a certain list, please let me know.