### PR TITLE
Unset $VIM and $VIMRUNTIME if not pointing to directories

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -518,8 +518,14 @@ function! s:get_executable_content(data_dir, prolog) abort
                                 \ 'mkdir -p ' . a:data_dir . "\n" .
                                 \ 'chmod 700 ' . a:data_dir . "\n" .
                                 \ 'cd ' . a:data_dir . "\n" .
-                                \ "unset NVIM_LISTEN_ADDRESS\n" .
                                 \ 'export PATH="$PATH:' . $PATH . "\"\n" .
+                                \ "unset NVIM_LISTEN_ADDRESS\n" .
+                                \ 'if [ -n "$VIM" ] && [ ! -d "$VIM" ]; then' . "\n" .
+                                \ "  unset VIM\n" .
+                                \ "fi\n" .
+                                \ 'if [ -n "$VIMRUNTIME" ] && [ ! -d "$VIMRUNTIME" ]; then' . "\n" .
+                                \ "  unset VIMRUNTIME\n" .
+                                \ "fi\n" .
                                 \ a:prolog . "\n" .
                                 \ "exec '" . s:get_progpath() . "' --headless --cmd 'let g:started_by_firenvim = v:true' -c 'call firenvim#run()'\n"
 endfunction


### PR DESCRIPTION
Imagine the following scenario:
- You are running a neovim appimage
- In that neovim instance, you have a terminal buffer
- In that terminal buffer, you run firefox/chrome/thunderbird
- You close down your neovim instance

The neovim appimage will have created four environment variables: $VIM,
$VIMRUNTIME, $APPDIR and $APPIMAGE. The browser will have inherited
these environment variables. When firenvim attempts to start a new
neovim instance, the new neovim instance inherits these variables.
The new neovim instance will attempt to use the runtime in $VIM and
$VIMRUNTIME, but won't find it, because the directories $VIM and
$VIMRUNTIME are pointing to were deleted when the parent appimage
shut down. This can potentially results in errors that prevent firenvim
from starting altogether.

We fix this by unsetting $VIM and $VIMRUNTIME if they're not pointing to
directories, with the hope that the neovim instance being started will
be able to find its real VIM annd VIMRUNTIME dirs.
