### PR TITLE
CI: use master branch of coverage-comparison action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,7 @@ jobs:
           failures.txt
         retention-days: 2
     - name: Process Coverage Report (Coverage only)
-      uses: glacambre/action-compare-coverage@v1.0.0
+      uses: glacambre/action-compare-coverage@master
       if: matrix.os == 'ubuntu' && matrix.browser == 'firefox' && matrix.neovim == 'stable'
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
It's fine because I'm the owner
