### PR TITLE
Refactor event handling

### DIFF
--- a/src/Neovim.ts
+++ b/src/Neovim.ts
@@ -15,7 +15,7 @@ export async function neovim(
     CanvasRenderer.events.on("resize", ({grid, width, height}: any) => {
         (functions as any).ui_try_resize_grid(grid, width, height);
     });
-    CanvasRenderer.events.on("frameResize", ({width, height}) => {
+    CanvasRenderer.events.on("frameResize", ({width, height}: any) => {
         page.resizeEditor(width, height);
     });
 

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,5 +1,9 @@
-import { getPageProxy } from "./page";
-import { setupInput } from "./input";
+import { EventEmitter  } from "./EventEmitter";
+import { addModifier, nonLiteralKeys, translateKey } from "./utils/keys";
+import { confReady, getGlobalConf, NvimMode } from "./utils/configuration";
+import { getPageProxy  } from "./page";
+import { isChrome      } from "./utils/utils";
+import { setupInput    } from "./input";
 
 const connectionPromise = browser.runtime.sendMessage({ funcName: ["getNeovimInstance"] });
 const pageLoaded = new Promise((resolve, reject) => {
@@ -7,10 +11,109 @@ const pageLoaded = new Promise((resolve, reject) => {
     setTimeout(reject, 10000)
 });
 
+class NvimInputEmitter extends EventEmitter<"input", (s: string) => void> {
+
+    private currentMode: NvimMode;
+
+    constructor(public keyHandler: HTMLElement, settings: ReturnType<typeof getGlobalConf>) {
+        super();
+        const ignoreKeys = settings.ignoreKeys;
+        this.keyHandler.addEventListener("keydown", (evt) => {
+            // This is a workaround for osx where pressing non-alphanumeric
+            // characters like "@" requires pressing <A-a>, which results
+            // in the browser sending an <A-@> event, which we want to
+            // treat as a regular @.
+            // So if we're seeing an alt on a non-alphanumeric character,
+            // we just ignore it and let the input event handler do its
+            // magic. This can only be tested on OSX, as generating an
+            // <A-@> keydown event with selenium won't result in an input
+            // event.
+            // Since coverage reports are only retrieved on linux, we don't
+            // instrument this condition.
+            /* istanbul ignore next */
+            if (evt.altKey && settings.alt === "alphanum" && !/[a-zA-Z0-9]/.test(evt.key)) {
+                return;
+            }
+            // Note: order of this array is important, we need to check OS before checking meta
+            const specialKeys = [["Alt", "A"], ["Control", "C"], ["OS", "D"], ["Meta", "D"]];
+            // The event has to be trusted and either have a modifier or a non-literal representation
+            if (evt.isTrusted
+                && (nonLiteralKeys[evt.key] !== undefined
+                    || specialKeys.find(([mod, _]: [string, string]) =>
+                                        evt.key !== mod && (evt as any).getModifierState(mod)))) {
+                const text = specialKeys.concat([["Shift", "S"]])
+                    .reduce((key: string, [attr, mod]: [string, string]) => {
+                        if ((evt as any).getModifierState(attr)) {
+                            return addModifier(mod, key);
+                        }
+                        return key;
+                    }, translateKey(evt.key));
+
+                let keys : string[] = [];
+                if (ignoreKeys[this.currentMode] !== undefined) {
+                    keys = ignoreKeys[this.currentMode].slice();
+                }
+                if (ignoreKeys.all !== undefined) {
+                    keys.push.apply(keys, ignoreKeys.all);
+                }
+                if (!keys.includes(text)) {
+                    this.emit("input", text);
+                    evt.preventDefault();
+                    evt.stopImmediatePropagation();
+                }
+            }
+        });
+
+        const acceptInput = ((evt: any) => {
+            this.emit("input", evt.target.value);
+            evt.preventDefault();
+            evt.stopImmediatePropagation();
+            evt.target.innerText = "";
+            evt.target.value = "";
+        }).bind(this);
+        this.keyHandler.addEventListener("input", (evt: any) => {
+            if (evt.isTrusted && !evt.isComposing) {
+                acceptInput(evt);
+            }
+        });
+        // On Firefox, Pinyin input method for a single chinese character will
+        // result in the following sequence of events:
+        // - compositionstart
+        // - input (character)
+        // - compositionend
+        // - input (result)
+        // But on Chrome, we'll get this order:
+        // - compositionstart
+        // - input (character)
+        // - input (result)
+        // - compositionend
+        // So Chrome's input event will still have its isComposing flag set to
+        // true! This means that we need to add a chrome-specific event
+        // listener on compositionend to do what happens on input events for
+        // Firefox.
+        // Don't instrument this branch as coverage is only generated on
+        // Firefox.
+        /* istanbul ignore next */
+        if (isChrome()) {
+            this.keyHandler.addEventListener("compositionend", (e: CompositionEvent) => {
+                acceptInput(e);
+            });
+        }
+    }
+
+    setMode(s: NvimMode) {
+        this.currentMode = s;
+    }
+}
+
 export const isReady = browser
     .runtime
     .sendMessage({ funcName: ["publishFrameId"] })
     .then(async (frameId: number) => {
+        await confReady;
         await pageLoaded;
-        return setupInput(getPageProxy(frameId), connectionPromise);
+        return setupInput(
+            getPageProxy(frameId),
+            new NvimInputEmitter(document.getElementById("keyhandler"), getGlobalConf()),
+            connectionPromise);
     });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -4,8 +4,9 @@ import { EventEmitter } from "./EventEmitter";
 
 type ResizeEvent = {grid: number, width: number, height: number};
 type FrameResizeEvent = {width: number, height: number}
-type ResizeEventHandler = (e: ResizeEvent | FrameResizeEvent) => void;
-type EventKind = "resize" | "frameResize";
+type ModeChangeEvent = NvimMode;
+type ResizeEventHandler = (e: ResizeEvent | FrameResizeEvent | ModeChangeEvent) => void;
+type EventKind = "resize" | "frameResize" | "modeChange";
 export const events = new EventEmitter<EventKind, ResizeEventHandler>();
 
 let glyphCache : any = {};
@@ -332,11 +333,6 @@ export function getGridId() {
     return 1;
 }
 
-export function getCurrentMode() {
-    const mode = globalState.mode;
-    return mode.modeInfo[mode.current].name;
-}
-
 function getCommandLineRect (state: State) {
     const [width, height] = getGlyphInfo(state);
     return {
@@ -580,6 +576,7 @@ const handlers : { [key:string] : (...args: any[])=>void } = {
     },
     mode_change: (_: string, modeIdx: number) => {
         globalState.mode.current = modeIdx;
+        events.emit("modeChange", globalState.mode.modeInfo[modeIdx].name);
         if (globalState.mode.styleEnabled) {
             const cursor = globalState.cursor;
             pushDamage(getGridId(), DamageKind.Cell, 1, 1, cursor.x, cursor.y);


### PR DESCRIPTION
This code extracts the browser-specific input code from input.ts (which
is supposed to be generic across thunderbird and browsers) and moves it
to frame.ts (which is browser-only).

In order to do so, input.ts can't directly reference the frame
keyhandler's anymore, instead an NvimInputEmitter class is created in
order to have a an object that deals with platform-specific intricacies
and offer a generic input event emitter that can be directly fed to
Neovim. Implementation of the thunderbird event emitter will happen in a
later commit.

This change also required breaking the direct reference to the renderer
the input-handling code had. This dependency was required in order to be
able to process key events differently depending on the current mode.
The choice made here was to have the renderer emit modeChange events and
have the generic input handling code feed that to the generic event
emitter. Ideally, the renderer shouldn't be the one noticing modechange
events at all. This will be implemented in later commits.
