### PR TITLE
thunderbird: fix plaintext editing

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -446,6 +446,14 @@ if (isThunderbird()) {
         // No need to remove the canvas when working with plaintext,
         // thunderbird will do that for us.
         if (details.isPlainText) {
+            // Firenvim has to cancel the beforeinput event on the compose
+            // window's documentElement in order to prevent the canvas from
+            // being destroyed. However, thunderbird has a bug where cancelling
+            // this event will prevent onBeforeSend from setting the compose
+            // window's content when editing plaintext emails.
+            // We work around this by telling the compose script to temporarily
+            // stop cancelling events.
+            await browser.tabs.sendMessage(tab.id, { args: [], funcName: ["pause_keyhandler"] });
             return { cancel: false, details: { plainTextBody: lines.join("\n") } };
         }
 

--- a/src/compose.ts
+++ b/src/compose.ts
@@ -104,18 +104,30 @@ class ThunderbirdPageEventEmitter extends PageEventEmitter {
 }
 
 class ThunderbirdKeyHandler extends KeydownHandler {
+    private enabled: boolean;
     constructor(settings: GlobalSettings) {
         super(document.documentElement, settings);
+        this.start();
         const acceptInput = ((evt: any) => {
-            this.emit("input", evt.data);
-            evt.preventDefault();
-            evt.stopImmediatePropagation();
+            if (this.enabled) {
+                this.emit("input", evt.data);
+                evt.preventDefault();
+                evt.stopImmediatePropagation();
+            }
         }).bind(this);
         document.documentElement.addEventListener("beforeinput", (evt: any) => {
             if (evt.isTrusted && !evt.isComposing) {
                 acceptInput(evt);
             }
         });
+    }
+
+    start() {
+        this.enabled = true;
+    }
+
+    stop() {
+        this.enabled = false;
     }
 
     focus() {
@@ -125,9 +137,15 @@ class ThunderbirdKeyHandler extends KeydownHandler {
 }
 
 confReady.then(async () => {
+    const keyHandler = new ThunderbirdKeyHandler(getGlobalConf());
+    const page = new ThunderbirdPageEventEmitter();
+    page.on("pause_keyhandler", () => {
+        keyHandler.stop();
+        setTimeout(() => keyHandler.start(), 1000);
+    });
     setupInput(
-        new ThunderbirdPageEventEmitter(),
+        page,
         canvas,
-        new ThunderbirdKeyHandler(getGlobalConf()),
+        keyHandler,
         connectionPromise);
 });

--- a/src/page.ts
+++ b/src/page.ts
@@ -169,13 +169,14 @@ type Promisify<T> = T extends Promise<any> ? T : Promise<T>;
 
 type ft = ReturnType<typeof getNeovimFrameFunctions>
 
-type PageEvents = "resize" | "frame_sendKey" | "get_buf_content";
+type PageEvents = "resize" | "frame_sendKey" | "get_buf_content" | "pause_keyhandler";
 type PageHandlers = (args: any[]) => void;
 export class PageEventEmitter extends EventEmitter<PageEvents, PageHandlers> {
     constructor() {
         super();
         browser.runtime.onMessage.addListener((request: any, _sender: any, _sendResponse: any) => {
             switch (request.funcName[0]) {
+                case "pause_keyhandler":
                 case "frame_sendKey":
                 case "resize":
                     this.emit(request.funcName[0], request.args);


### PR DESCRIPTION
This works around a thunderbird bug where cancelling beforeinput events
on the compose window's document will prevent the onBeforeSend listener
from setting the compose window's content.

Closes #1169
