### PR TITLE
ci: mark job as neutral if failed because of dependencies

### DIFF
--- a/.github/actions/mark-neutral/action.yml
+++ b/.github/actions/mark-neutral/action.yml
@@ -1,0 +1,9 @@
+name: 'Mark neutral'
+description: 'Mark job as neutral'
+inputs:
+  github_token:
+    description: 'Github token'
+    required: 'true'
+runs:
+  using: 'node12'
+  main: 'main.js'

--- a/.github/actions/mark-neutral/main.js
+++ b/.github/actions/mark-neutral/main.js
@@ -1,0 +1,24 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+
+async function main() {
+  const token = core.getInput("github_token", { required: true });
+
+  const pull_request = github.context.payload.pull_request;
+  const owner = github.context.repo.owner;
+  const repo = github.context.repo.repo;
+  const baseline_ref = pull_request.base.ref;
+  const baseline = ref_to_coverage_artifact_name(baseline_ref);
+  const head_sha = pull_request.head.sha;
+  const head_url = pull_request.head.repo.html_url + "/blob/" + head_sha;
+  const octokit = github.getOctokit(token);
+
+  const check_suites = await octokit.request('GET /repos/{owner}/{repo}/commits/{ref}/check-suites', {
+    owner,
+    repo,
+    ref: head_sha,
+  });
+  core.info(JSON.stringify(check_suites));
+}
+
+main()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,61 +12,13 @@ env:
   TESTING: 1
 
 jobs:
-  tslint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@master
-    - name: Install NPM dependencies
-      run: npm ci
-    - name: Install eslint
-      run: npm install eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser
-    - name: Run ESlint
-      run: '"$(npm bin)/eslint" "./**/*.ts"'
-    - name: Run addons-linter
-      run: 'npm run build && npm run pack && "$(npm bin)/addons-linter" target/xpi/firefox-latest.xpi' 
-
   test:
-    needs: tslint
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu, macos, windows]
-        browser: [firefox, chrome]
-        neovim: [stable, nightly]
 
     runs-on: ${{ matrix.os }}-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Install ffmpeg (Linux)
-      if: matrix.os == 'ubuntu'
-      run: sudo apt update -y && sudo apt install -y ffmpeg
-    - name: Install ffmpeg (MacOs)
-      if: matrix.os == 'macos'
-      run: curl -JL https://evermeet.cx/ffmpeg/get/zip --output ffmpeg.zip && unzip ffmpeg.zip && echo "$PWD" >> $GITHUB_PATH
-    - name: Install ffmpeg (Windows)
-      if: matrix.os == 'windows'
-      run: choco install ffmpeg
-    - name: Install Firefox Dev Edition (Linux)
-      if: matrix.browser == 'firefox' && matrix.os == 'ubuntu'
-      run: |
-        sudo npm install -g get-firefox
-        get-firefox --platform linux --branch devedition --extract --target $HOME
-        echo "$HOME/firefox" >> $GITHUB_PATH
-    - name: Install Firefox Dev Edition (MacOS)
-      if: matrix.browser == 'firefox' && matrix.os == 'macos'
-      run: |
-        brew install --cask homebrew/cask-versions/firefox-developer-edition
-        echo "/Applications/Firefox Developer Edition.app/Contents/MacOS/" >> $GITHUB_PATH
-    - name: Install Firefox Dev Edition (Windows)
-      if: matrix.browser == 'firefox' && matrix.os == 'windows'
-      run: |
-        choco install firefox-dev --pre
-        echo "C:\Program Files\Firefox Dev Edition" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install Neovim
       id: neovim
       uses: rhysd/action-setup-vim@v1
@@ -75,63 +27,6 @@ jobs:
         neovim: true
         version: ${{ matrix.neovim }}
     - name: Fail if Neovim not installed
-      uses: actions/github-script@v4
-      with:
-        script: |
-          return github.request('PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}', {
-            owner: context.repo.owner,
-            repo: context.repo.owner,
-            check_run_id: context.runId,
-            conclusion: "neutral",
-          })
-    - name: Install NPM dependencies
-      if: steps.neovim.outputs.executable != ''
-      timeout-minutes: 5
-      run: npm ci
-    - name: Build Firenvim
-      if: steps.neovim.outputs.executable != ''
-      timeout-minutes: 1
-      run: npm run webpack -- --env=${{ matrix.browser }}-testing
-    - name: Instrument Firenvim (Linux/Firefox/Stable only)
-      if: steps.neovim.outputs.executable != '' && matrix.os == 'ubuntu' && matrix.browser == 'firefox' && matrix.neovim == 'stable'
-      run: npm run nyc -- instrument --in-place target/${{ matrix.browser }}
-    - name: Pack Firenvim (Firefox)
-      if: steps.neovim.outputs.executable != '' && matrix.browser == 'firefox'
-      run: npm run pack
-    - name: Install Manifest
-      if: steps.neovim.outputs.executable != ''
-      run: npm run install_manifests
-    - name: Test (Linux)
-      timeout-minutes: 10
-      if: steps.neovim.outputs.executable != '' && matrix.os == 'ubuntu'
-      # Multiple attempts to increase FPS to 60 have been made: use libx264,
-      # using raw output... Nothing worked. Spending more effort on this will
-      # only result in suffering and wasted time.
-      run: xvfb-run --auto-servernum -s "-screen 0 920x690x24" sh -c '(sleep 3 && ffmpeg -loglevel error -t 240 -an -video_size 920x690 -framerate 30 -f x11grab -i $DISPLAY video.webm) & npm run jest -- ${{ matrix.browser }}'
-    - name: Test (MacOS)
-      if: steps.neovim.outputs.executable != '' && matrix.os == 'macos'
-      timeout-minutes: 10
-      run: |
-        ffmpeg -loglevel warning -t 240 -framerate 30 -f avfoundation -i "0:0" video.webm &
-        exit_code=0 && npm run jest -- ${{ matrix.browser }} || exit_code=$? && sleep 20 && exit $exit_code
-    - name: Test (Windows)
-      if: steps.neovim.outputs.executable != '' && matrix.os == 'windows'
-      timeout-minutes: 10
-      run: |
-        Start-Job { ffmpeg -loglevel warning -t 240 -framerate 30 -f gdigrab -i desktop D:\a\firenvim\firenvim\video.webm }
-        npm run jest -- ${{ matrix.browser }}
-        Get-Job | Wait-Job
-    - name: Artifact upload (failure only)
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: ${{ matrix.os }}-${{ matrix.browser }}-${{ matrix.neovim }}
-        path: |
-          video.webm
-          failures.txt
-        retention-days: 2
-    - name: Process Coverage Report (Coverage only)
-      uses: glacambre/action-compare-coverage@master
-      if: steps.neovim.outputs.executable != '' && matrix.os == 'ubuntu' && matrix.browser == 'firefox' && matrix.neovim == 'stable'
+      uses: ./.github/actions/mark-neutral
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,39 +68,54 @@ jobs:
         choco install firefox-dev --pre
         echo "C:\Program Files\Firefox Dev Edition" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install Neovim
+      id: neovim
       uses: rhysd/action-setup-vim@v1
+      continue-on-error: true
       with:
         neovim: true
         version: ${{ matrix.neovim }}
+    - name: Fail if Neovim not installed
+      uses: actions/github-script@v4
+      with:
+        script: |
+          return github.request('PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}', {
+            owner: context.repo.owner,
+            repo: context.repo.owner,
+            check_run_id: context.runId,
+            conclusion: "neutral",
+          })
     - name: Install NPM dependencies
+      if: steps.neovim.outputs.executable != ''
       timeout-minutes: 5
       run: npm ci
     - name: Build Firenvim
+      if: steps.neovim.outputs.executable != ''
       timeout-minutes: 1
       run: npm run webpack -- --env=${{ matrix.browser }}-testing
     - name: Instrument Firenvim (Linux/Firefox/Stable only)
-      if: matrix.os == 'ubuntu' && matrix.browser == 'firefox' && matrix.neovim == 'stable'
+      if: steps.neovim.outputs.executable != '' && matrix.os == 'ubuntu' && matrix.browser == 'firefox' && matrix.neovim == 'stable'
       run: npm run nyc -- instrument --in-place target/${{ matrix.browser }}
     - name: Pack Firenvim (Firefox)
-      if: matrix.browser == 'firefox'
+      if: steps.neovim.outputs.executable != '' && matrix.browser == 'firefox'
       run: npm run pack
     - name: Install Manifest
+      if: steps.neovim.outputs.executable != ''
       run: npm run install_manifests
     - name: Test (Linux)
       timeout-minutes: 10
-      if: matrix.os == 'ubuntu'
+      if: steps.neovim.outputs.executable != '' && matrix.os == 'ubuntu'
       # Multiple attempts to increase FPS to 60 have been made: use libx264,
       # using raw output... Nothing worked. Spending more effort on this will
       # only result in suffering and wasted time.
       run: xvfb-run --auto-servernum -s "-screen 0 920x690x24" sh -c '(sleep 3 && ffmpeg -loglevel error -t 240 -an -video_size 920x690 -framerate 30 -f x11grab -i $DISPLAY video.webm) & npm run jest -- ${{ matrix.browser }}'
     - name: Test (MacOS)
-      if: matrix.os == 'macos'
+      if: steps.neovim.outputs.executable != '' && matrix.os == 'macos'
       timeout-minutes: 10
       run: |
         ffmpeg -loglevel warning -t 240 -framerate 30 -f avfoundation -i "0:0" video.webm &
         exit_code=0 && npm run jest -- ${{ matrix.browser }} || exit_code=$? && sleep 20 && exit $exit_code
     - name: Test (Windows)
-      if: matrix.os == 'windows'
+      if: steps.neovim.outputs.executable != '' && matrix.os == 'windows'
       timeout-minutes: 10
       run: |
         Start-Job { ffmpeg -loglevel warning -t 240 -framerate 30 -f gdigrab -i desktop D:\a\firenvim\firenvim\video.webm }
@@ -117,6 +132,6 @@ jobs:
         retention-days: 2
     - name: Process Coverage Report (Coverage only)
       uses: glacambre/action-compare-coverage@master
-      if: matrix.os == 'ubuntu' && matrix.browser == 'firefox' && matrix.neovim == 'stable'
+      if: steps.neovim.outputs.executable != '' && matrix.os == 'ubuntu' && matrix.browser == 'firefox' && matrix.neovim == 'stable'
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,24 +8,12 @@ on:
     branches:
     - '*'
 
-env:
-  TESTING: 1
-
 jobs:
   test:
-
-    runs-on: ${{ matrix.os }}-latest
-
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Install Neovim
-      id: neovim
-      uses: rhysd/action-setup-vim@v1
-      continue-on-error: true
-      with:
-        neovim: true
-        version: ${{ matrix.neovim }}
     - name: Fail if Neovim not installed
       uses: ./.github/actions/mark-neutral
       with:


### PR DESCRIPTION
This should help with failures caused by neovim nightly not being
available.
