### PR TITLE
Use window.eval for executeInPage on Firefox when possible

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -273,6 +273,12 @@ export class PageEventEmitter extends EventEmitter<PageEvents, PageHandlers> {
                     break;
                 case "get_buf_content":
                     return new Promise(resolve => this.emit(request.funcName[0], resolve));
+                case "evalInPage":
+                case "resizeEditor":
+                case "getElementContent":
+                case "getEditorInfo":
+                    // handled by frame function handler
+                    break;
                 default:
                     console.error("Unhandled page request:", request);
             }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -33,6 +33,19 @@ export function isThunderbird() {
 // embedding a script element that runs the piece of code and emits its result
 // as an event.
 export function executeInPage(code: string): Promise<any> {
+    // On firefox, use an API that allows circumventing some CSP restrictions
+    // Use wrappedJSObject to detect availability of said API
+    // DON'T use window.eval on other plateforms - it doesn't have the
+    // semantics we need!
+    if ((window as any).wrappedJSObject) {
+        return new Promise((resolve, reject) => {
+            try {
+                resolve(window.eval(code));
+            } catch (e) {
+                reject(e);
+            }
+        });
+    }
     return new Promise((resolve, reject) => {
         const script = document.createElement("script");
         const eventId = (new URL(browser.runtime.getURL(""))).hostname + Math.random();


### PR DESCRIPTION
Closes #1287
