### PR TITLE
fix firenvim being unable to start due to broken configs

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -140,6 +140,13 @@ async function checkVersion(nvimVersion: string) {
     }
     updateIcon();
 }
+function warnUnexpectedMessages(messages: string[]) {
+    if (messages === undefined || !Array.isArray(messages) || messages.length < 1) {
+        return;
+    }
+    warning = messages.join("\n");
+    updateIcon();
+}
 
 // Function called in order to fill out default settings. Called from updateSettings.
 function applySettings(settings: any) {
@@ -168,6 +175,7 @@ function createNewInstance() {
             (nvim as any).replied = true;
             clearTimeout(errorTimeout);
             checkVersion(resp.version);
+            warnUnexpectedMessages(resp.messages);
             applySettings(resp.settings).finally(() => {
                 resolve({
                     kill: () => nvim.disconnect(),

--- a/tests/chrome.ts
+++ b/tests/chrome.ts
@@ -50,7 +50,8 @@ import {
  testTakeoverNonEmpty,
  testTakeoverOnce,
  testToggleFirenvim,
- testVimrcFailure,
+ testBrokenVimrc,
+ testErrmsgVimrc,
  testWorksInFrame,
 } from "./_common"
 import { setupVimrc, resetVimrc } from "./_vimrc";
@@ -203,7 +204,10 @@ describe("Chrome", () => {
         t("EvalJS", testEvalJs);
         t("Takeover: empty", testTakeoverEmpty);
         t("Toggling firenvim", testToggleFirenvim);
-        t("Buggy Vimrc", testVimrcFailure, 60000);
+        t("Buggy Vimrc", testBrokenVimrc, 60000);
+        if (neovimVersion > 0.7) {
+                t("Vimrc emits error messages", testErrmsgVimrc);
+        }
         if (process.platform !== "darwin") {
                 // This test somehow fails on osx+chrome, so don't run it on this combination!
                 t("Mouse", testMouse);

--- a/tests/firefox.ts
+++ b/tests/firefox.ts
@@ -52,7 +52,8 @@ import {
  testUnfocusedKillEditor,
  testUntrustedInput,
  testUpdates,
- testVimrcFailure,
+ testBrokenVimrc,
+ testErrmsgVimrc,
  testWorksInFrame,
 } from "./_common"
 import { setupVimrc, resetVimrc } from "./_vimrc";
@@ -176,7 +177,10 @@ describe("Firefox", () => {
         t("EvalJS", testEvalJs);
         t("Takeover: empty", testTakeoverEmpty);
         t("Toggling firenvim", testToggleFirenvim);
-        t("Buggy Vimrc", testVimrcFailure, 60000);
+        t("Buggy Vimrc", testBrokenVimrc, 60000);
+        if (neovimVersion > 0.7) {
+                t("Vimrc emits error messages", testErrmsgVimrc);
+        }
         t("Mouse", testMouse);
         t("Untrusted input", testUntrustedInput);
         if (process.platform === "linux") {


### PR DESCRIPTION
Thanks to https://github.com/neovim/neovim/pull/15910 we can now work
around broken configs and start firenvim despite the user messing things
up. Cherry on top, we can warn them through the browser UI.

Closes #1196, #1209
