### PR TITLE
Consider E245 while parsing font name

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -286,6 +286,7 @@ export function parseSingleGuifont(guifont: string, defaults: any) {
     if (defaults[fontFamily]) {
         result[fontFamily] += `, ${defaults[fontFamily]}`;
     }
+    result[fontFamily] = result[fontFamily].replaceAll('_', ' '); // :h E245
     return options.slice(1).reduce((acc, option) => {
             switch (option[0]) {
                 case "h":


### PR DESCRIPTION
`:h E245` says
```vimhelp
- A '_' can be used in the place of a space, so you don't need to use
  backslashes to escape the spaces.
- Examples: >
    :set guifont=courier_new:h12:w5:b:cRUSSIAN
    :set guifont=Andale_Mono:h7.5:w4.5
```
As is indicated by [public dotfiles](https://cs.github.com/?q=%2F%20guifont.*_%2F%20language%3A%22Vim%20Script%22&scopeName=All%20repos&scope=), underscores are often used to represent spaces.

Also see https://github.com/glacambre/firenvim/issues/972#issuecomment-873635158