### PR TITLE
feat(nix): add another path to the set of contant_paths

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -530,6 +530,7 @@ function! s:get_progpath() abort
                         \ 'pattern': '^/nix/store/',
                         \ 'constant_paths': [
                                 \ expand('$HOME/.nix-profile/bin/nvim'),
+                                \ expand('/etc/profiles/per-user/$USER/bin/nvim'),
                                 \ '/run/current-system/sw/bin/nvim'
                         \ ]
                 \ }


### PR DESCRIPTION
`$HOME/.nix-profile` isn't enough; it will only ever exist (i.e. point
to a valid profile in `/nix/var/nix/profiles`) if the user installs
software via `nix-env`. Many nix users, and indeed most nixOS users,
configure their systems through `user.packages` and/or
`environment.systemPackages`. While the latter creates symlinks
in `/run/current-system/sw/bin`, the former does not.
`/etc/profiles/per-user/$USER` will contain symlinks for packages
installed via `user.packages` *and* those installed via home-manager's
`home.packages`.
