### PR TITLE
Use `msgpack.Decoder` to decode WebSocket messages

### DIFF
--- a/src/Stdout.ts
+++ b/src/Stdout.ts
@@ -24,7 +24,6 @@ export class Stdout extends EventEmitter<MessageKind, MessageHandler>{
     }
 
     public setTypes(types: {[key: string]: { id: number }}) {
-        this.msgpackConfig.codec = msgpack.createCodec({ preset: true });
         Object
             .entries(types)
             .forEach(([_, { id }]) =>

--- a/src/Stdout.ts
+++ b/src/Stdout.ts
@@ -8,13 +8,19 @@ type NotificationHandler = (name: string, args: any[]) => void;
 type MessageHandler = RequestHandler | ResponseHandler | NotificationHandler;
 export class Stdout extends EventEmitter<MessageKind, MessageHandler>{
     private messageNames = new Map<number, MessageKind>([[0, "request"], [1, "response"], [2, "notification"]]);
-    // Holds previously-received, incomplete and unprocessed messages
-    private prev = new Uint8Array(0);
-    private msgpackConfig = {} as msgpack.DecoderOptions;
+    private msgpackConfig: msgpack.DecoderOptions = {
+        // Create the codec object early so the Decoder is initialized with it.
+        // If that was created in `setTypes`, the `decoder` would already be
+        // initialized with the default codec.
+        // https://github.com/kawanet/msgpack-lite/blob/5b71d82cad4b96289a466a6403d2faaa3e254167/lib/decode-buffer.js#L17
+        codec: msgpack.createCodec({ preset: true }),
+    };
+    private decoder = msgpack.Decoder(this.msgpackConfig);
 
     constructor(private socket: WebSocket) {
         super();
         this.socket.addEventListener("message", this.onMessage.bind(this));
+        this.decoder.on("data", this.onDecodedChunk.bind(this));
     }
 
     public setTypes(types: {[key: string]: { id: number }}) {
@@ -30,29 +36,26 @@ export class Stdout extends EventEmitter<MessageKind, MessageHandler>{
 
     private onMessage(msg: any) {
         const msgData = new Uint8Array(msg.data);
-        let data = new Uint8Array(msgData.byteLength + this.prev.byteLength);
-        data.set(this.prev);
-        data.set(msgData, this.prev.length);
-        while (true) {
-            let decoded;
-            try {
-                decoded = msgpack.decode(data, this.msgpackConfig);
-            } catch (e) {
-                this.prev = data;
-                return;
-            }
-            const encoded = msgpack.encode(decoded);
-            data = data.slice(encoded.byteLength);
-            const [kind, reqId, data1, data2] = decoded;
-            const name = this.messageNames.get(kind);
-            /* istanbul ignore else */
-            if (name) {
-                this.emit(name, reqId, data1, data2);
-            } else {
-                // Can't be tested because this would mean messages that break
-                // the msgpack-rpc spec, so coverage impossible to get.
-                console.error(`Unhandled message kind ${name}`);
-            }
+        try {
+            this.decoder.decode(msgData);
+        } catch (error) {
+            // NOTE: this branch was not hit during testing, but theoretically could happen
+            // due to
+            // https://github.com/kawanet/msgpack-lite/blob/5b71d82cad4b96289a466a6403d2faaa3e254167/lib/flex-buffer.js#L52
+            console.log("msgpack decode failed", error);
+        }
+    }
+
+    private onDecodedChunk(decoded: [number, unknown, unknown, unknown]) {
+        const [kind, reqId, data1, data2] = decoded;
+        const name = this.messageNames.get(kind);
+        /* istanbul ignore else */
+        if (name) {
+            this.emit(name, reqId, data1, data2);
+        } else {
+            // Can't be tested because this would mean messages that break
+            // the msgpack-rpc spec, so coverage impossible to get.
+            console.error(`Unhandled message kind ${name}`);
         }
     }
 }


### PR DESCRIPTION
The previous handling of slicing partially-buffered data based on the decoded and later encoded message turned out to be faulty. I suspect the encoded message could have a different byte length than the received message. The fact that [the Neovim change](https://github.com/neovim/neovim/commit/5d6987210578f5f1c3151988b99a9411f9603374#diff-a1fbec4cf4e555c5adb8e700b2f7f4f7368f0317c9e2b0b5a3112f273df794bfR83) mentioned in #1382 uses fixed-size arrays may support this claim.

The `msgpack.Decoder` class already does that logic internally. The difference is that it knows exactly how many bytes were read. It can [slice the internal buffer in a more precise way](https://github.com/kawanet/msgpack-lite/blob/5b71d82cad4b96289a466a6403d2faaa3e254167/lib/flex-buffer.js#L91).

I didn't run the jest tests or did any verification outside of Chrome (Version 103.0.5060.114 (Official Build) (64-bit)) on Ubuntu 20.04 LTS. I was just hoping to get _some_ fix out of the door.

Fixes <https://github.com/glacambre/firenvim/issues/1382>

---

Me editing this PR description with `firenvim`

https://user-images.githubusercontent.com/889383/178975290-3407fc21-3bc1-404a-a2bd-4678a98197b9.mp4

The canvas is blurry because I am on a HiDPI monitor (`window.devicePixelRatio === 2`) and I had to disable the scaling done in `src/renderer.ts` (hardcoded `1` everywhere `window.devicePixelRatio` is used) because with HiDPI the font size was too small. I bet this is not related to this bugfix. It seems to be related to https://github.com/glacambre/firenvim/issues/869

---

There are still some "Unhandled page request" errors logged to the browser console upon closing a firenvim instance with `:x`. The basic functionality of editing using Neovim inside of a `textarea` seems to be working well.

![image](https://user-images.githubusercontent.com/889383/178974795-c348e707-6e7f-47fd-8206-fb02b7ba3408.png)
