### PR TITLE
docker: pin node version to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS build-stage
+FROM node:18-alpine AS build-stage
 SHELL ["/bin/sh", "-o", "pipefail", "-c"]
 
 RUN apk add --no-cache neovim


### PR DESCRIPTION
previously was set to lts, which broke the docker build when lts was
upgraded to 18