### PR TITLE
Also disable messages when cmdline is set to "none" (#1442)

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -684,6 +684,9 @@ function scheduleFrame() {
 }
 
 function paintMessages(state: State) {
+    if (settings.cmdline === "none") {
+        return;
+    }
     const ctx = state.context;
     const gId = getGridId();
     const messagesPosition = state.messagesPositions[gId];


### PR DESCRIPTION
Fusing messages and cmdline isn't ideal, but as neovim doesn't offer a
way to get separate cmdline and messages, it's probably better not to
offer a second configuration option that only works conditional on the
"cmdline" setting.
