### PR TITLE
Updated the install instructions for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,14 @@ Before installing anything please read [SECURITY.md](SECURITY.md) and make sure 
         ```lua
         {
             'glacambre/firenvim',
-            build = function() vim.fn['firenvim#install'](0) end,
 
             -- Lazy load firenvim
             -- Explanation: https://github.com/folke/lazy.nvim/discussions/463#discussioncomment-4819297
-            cond = not not vim.g.started_by_firenvim
+            cond = not not vim.g.started_by_firenvim,
+            build = function()
+                require("lazy").load({ plugins = "firenvim", wait = true })
+                vim.fn["firenvim#install"](0)
+            end
         }
 
     * [minpac](https://github.com/k-takata/minpac)


### PR DESCRIPTION
Now you don't have to enable firenvim manually to run the install script when you're updating your plugins from the terminal. Thanks to @axieax for the build function.