### PR TITLE
Fix chrome://extensions/shortcuts missing options

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -16,13 +16,13 @@
          }
       },
       "send_C-n": {
-         "description": "Send <C-n> to firenvim."
+         "description": "Send Ctrl-n to firenvim."
       },
       "send_C-t": {
-         "description": "Send <C-t> to firenvim."
+         "description": "Send Ctrl-t to firenvim."
       },
       "send_C-w": {
-         "description": "Send <C-w> to firenvim."
+         "description": "Send Ctrl-w to firenvim."
       },
       "toggle_firenvim": {
          "description": "Toggle Firenvim in the current tab."


### PR DESCRIPTION
At least on Chromium 113.0.5672.126 (the current version in Fedora 37), command descriptions with strings that look like HTML tags (e.g. \<C-w\>) prevent that option and all the options that follow from being shown in chrome://extensions/shortcuts.

Unknown tags, \<script\> and probably others trigger this error. Some tags like \<b\> don't trigger it but they are parsed as plaintext, so this looks like a Chromium bug.

Anyway, this patch replaces \<C-w\> and similar with Ctrl-w allowing commands to be configured in chrome://extension/shorcuts. I tried escaping the original text but didn't find a way.