### PR TITLE
Updated the installation instructions for lazy.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ Before installing anything please read [SECURITY.md](SECURITY.md) and make sure 
 
             -- Lazy load firenvim
             -- Explanation: https://github.com/folke/lazy.nvim/discussions/463#discussioncomment-4819297
-            cond = not not vim.g.started_by_firenvim,
+            lazy = not vim.g.started_by_firenvim,
             build = function()
-                require("lazy").load({ plugins = "firenvim", wait = true })
                 vim.fn["firenvim#install"](0)
             end
         }


### PR DESCRIPTION
The previous installation instructions no longer work as @folke has updated the cond keyword to behave the same as the enabled keyword, which means that firenvim wouldn't install after an update because lazy.nvim will not load disabled plugins.