### PR TITLE
Exclude 'aria-readonly' in localSettings selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ vim.g.firenvim_config.localSettings["https?://[^/]+\\.co\\.uk/"] = { takeover = 
 The `selector` attribute of a localSetting controls what elements Firenvim automatically takes over. Here's the default value:
 
 ```lua
-vim.g.firenvim_config.localSettings['.*'] = { selector = 'textarea:not([readonly]), div[role="textbox"]' }
+vim.g.firenvim_config.localSettings['.*'] = { selector = 'textarea:not([readonly], [aria-readonly]), div[role="textbox"]' }
 ```
 
 If you don't want to use Firenvim with rich text editors (e.g. Gmail, Outlook, Slack…) as a general rule, you might want to restrict Firenvim to simple textareas:

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -112,7 +112,7 @@ export function mergeWithDefaults(os: string, settings: any): IConfig {
         content: "text",
         priority: 0,
         renderer: "canvas",
-        selector: 'textarea:not([readonly]), div[role="textbox"]',
+        selector: 'textarea:not([readonly], [aria-readonly]), div[role="textbox"]',
         // "takeover": "always" | "once" | "empty" | "nonempty" | "never"
         // #265: On "once", don't automatically bring back after :q'ing it
         takeover: "always",


### PR DESCRIPTION
What this PR is trying to fix: given https://github.com/glacambre/firenvim/blob/master/tsconfig.json as an example, clicking in the code will trigger firenvim to start an nvim instance. This should not happen, the textarea can't be edited

Tested manually first with the default values
```js
document.querySelectorAll('textarea:not([readonly]), div[role="textbox"]')
```
and with
```js
document.querySelectorAll('textarea:not([readonly], [aria-readonly]), div[role="textbox"]')
```

Tested locally by building the extension with `DOCKER_BUILDKIT=1 docker build . -t firenvim --output target`

Closes #1537 