### PR TITLE
fix: run scripts in noninteractive shell (#1547)

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -887,7 +887,7 @@ function! firenvim#install(...) abort
                         call s:maybe_execute('writefile', split(l:ps1_content, "\n"), l:ps1_path)
                         call s:maybe_execute('setfperm', l:ps1_path, 'rwx------')
                         try
-                                let o = s:maybe_execute('system', ['powershell.exe', '-Command', '-'], readfile(l:ps1_path))
+                                let o = s:maybe_execute('system', ['powershell.exe', '-NonInteractive', '-Command', '-'], readfile(l:ps1_path))
                         catch /powershell.exe' is not executable/
                                 let l:failure = v:true
                                 let l:msg = 'Error: Firenvim could not find powershell.exe'
@@ -955,7 +955,7 @@ function! firenvim#uninstall() abort
                 if has('win32') || s:is_wsl
                         echo 'Removing registry key for ' . l:name . '. This may take a while.'
                         let l:ps1_content = 'Remove-Item -Path "' . l:cur_browser['registry_key'] . '" -Recurse'
-                        let o = system(['powershell.exe', '-Command', '-'], [l:ps1_content])
+                        let o = system(['powershell.exe', '-NonInteractive', '-Command', '-'], [l:ps1_content])
                         if v:shell_error
                           echo o
                         endif


### PR DESCRIPTION
Firenvim on Windows relys on powershell scripts to run registry keys installation and uninstallation. Here are the codes:

https://github.com/glacambre/firenvim/blob/8c6c00aae7e5762cbcb4cd0df5848e959c4a9572/autoload/firenvim.vim#L890

https://github.com/glacambre/firenvim/blob/8c6c00aae7e5762cbcb4cd0df5848e959c4a9572/autoload/firenvim.vim#L958

During debugging, I add `echo o` right after calling the `system` function, which then shows error

```text
Cannot load PSReadline module.  Console is running without PSReadline.
```

But weirdly, `v:shell_error` is still `0`. `PSReadline` is a module usually installed for interactive prompt usage. `Powershell.exe` provides option `-NonInterative` for running automated scripts in non-interactive shell. Adding the `-NonInteractive` option fixes #1547 as the scripts run successfully without error.

> [!NOTE]
> This pull request only fixes firenvim installation on Windows host and
WSL2 environment. Uninstallation scripts run successfully when running firenvim on the host (`%LOCALAPPDATA/firenvim/*` files and corresponding registry keys are removed); run `firenvim#uninstall()` on WSL side only removes the binary in WSL
(`stdpath('data')/firenvim` in WSL or
`$HOME/.local/share/firenvim/firenvim`)
>
> A separate issue #1576 tracks the uninstallation bug on WSL side