### PR TITLE
fix: remove incorrect WSL env variable (#1578)

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -918,7 +918,7 @@ function! firenvim#install(...) abort
         endfor
 
         if !s:is_wsl
-                let s:is_wsl = !empty($WSLENV) || !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
+                let s:is_wsl = !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
                 if s:is_wsl
                         echo 'Installation complete on the wsl side. Performing install on the windows side.'
                         call firenvim#install(l:force_install, l:script_prolog)


### PR DESCRIPTION
Variable `s:is_wsl` indicates whether firenvim is running on the WSL side or on the Windows host system. Currently, `s:is_wsl` checks three environment variables `$WSLENV`, `WSL_DISTRO_NAME`, and `WSL_INTEROP`. The following table lists the values of these env vars on the host system and on the WSL2 system:

| ENV_VAR            | Windows Host                | WSL2                        |
|--------------------|-----------------------------|-----------------------------|
| `$WSLENV`          | `WT_SESSION:WT_PROFILE_ID:` | `WT_SESSION:WT_PROFILE_ID:` |
| `$WSL_DISTRO_NAME` | empty                       | `Ubuntu-22.04`              |
| `$WSL_INTEROP`     | empty                       | `/run/WSL/1133_interop`     |

The incorrect env var `$WSLENV` is used in

https://github.com/glacambre/firenvim/blob/8c6c00aae7e5762cbcb4cd0df5848e959c4a9572/autoload/firenvim.vim#L921

As a result, `s:is_wsl` is set to `1` even when firenvim is installed from the host system, and thus directory
`mnt/c/users/myusername/appdata/local/firenvim` is created under the `C:` drive.