### PR TITLE
refactor: add has('wsl') to help set s:is_wsl

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -918,7 +918,7 @@ function! firenvim#install(...) abort
         endfor
 
         if !s:is_wsl
-                let s:is_wsl = !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
+                let s:is_wsl = has('wsl') || !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
                 if s:is_wsl
                         echo 'Installation complete on the wsl side. Performing install on the windows side.'
                         call firenvim#install(l:force_install, l:script_prolog)
@@ -973,7 +973,7 @@ function! firenvim#uninstall() abort
         endfor
 
         if !s:is_wsl
-                let s:is_wsl = !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
+                let s:is_wsl = has('wsl') || !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
                 if s:is_wsl
                         echo 'Uninstallation complete on the wsl side. Performing uninstall on the windows side.'
                         call firenvim#uninstall()


### PR DESCRIPTION
`vim.fn.has()` or `has()` can help check current runtime condition.

As `:h has()` indicates:

> Returns 1 if {feature} is supported, 0 otherwise.
> ...
> 2. Runtime condition or other pseudo-feature. For example the
>     "win32" feature checks if the current system is Windows:
>         :if has("win32")
>         				*feature-list*
>     List of supported pseudo-feature names:
>         ...             ......
>         wsl		WSL (Windows Subsystem for Linux) system.

Inspired from:

https://github.com/neovim/neovim/blob/dc466f9a63ede5e2bbddc33688c0c972abfe9a52/runtime/autoload/provider/clipboard.vim#L132