### PR TITLE
TROUBLESHOOTING.md: Remove reference to txti.es

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -70,7 +70,7 @@ In your browser, open the background console. This requires the following steps:
     * Click on the `background page` link.
     * If the console already contains messages, empty by pressing `<C-l>`.
 
-Then, navigate to a page with a textarea (I really like `http://txti.es` for this). Open the content console (`<CS-I>` on both firefox and chrome/ium). If you're using firefox, also open and clear the Browser Console (`<CS-J>`). Then, click on the textarea. This should result in messages being printed in the console. If it doesn't, try clicking on the Firenvim icon next to the urlbar. If no messages are logged there either, try clicking on the `Reload settings` button.
+Then, navigate to a page with a textarea. Open the content console (`<CS-I>` on both firefox and chrome/ium). If you're using firefox, also open and clear the Browser Console (`<CS-J>`). Then, click on the textarea. This should result in messages being printed in the console. If it doesn't, try clicking on the Firenvim icon next to the urlbar. If no messages are logged there either, try clicking on the `Reload settings` button.
 
 ### Make sure firenvim can access your config files
 


### PR DESCRIPTION
The http://txti.es website shut down in July 2023:

> Due to bad actors, txti will be shutting permanently on
> July 1, 2023.

This commit removes the references to txti.es from
TROUBLESHOOTING.md.