### PR TITLE
fix: reset s:is_wsl after calling (un)install

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -895,6 +895,36 @@ function! firenvim#install(...) abort
                 endif
         endif
 
+        try
+                if !s:is_wsl
+                        call firenvim#internal_install(l:force_install, l:script_prolog)
+                        let s:is_wsl = has('wsl') || !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
+                        if s:is_wsl
+                                echo 'Installation complete on the wsl side. Performing install on the windows side.'
+                                call firenvim#internal_install(l:force_install, l:script_prolog)
+                        endif
+                else
+                        throw 'firenvim#install is called, but s:is_wsl has not been reset. Please report this bug.'
+                endif
+        finally
+                let s:is_wsl = v:false
+        endtry
+
+        if luaeval('lvim~=nil')
+                echo 'WARNING: Lunarvim is not supported. Do not open issues if you use Lunarvim.'
+        endif
+endfunction
+
+function! firenvim#internal_install(...) abort
+        let l:force_install = 0
+        let l:script_prolog = ''
+        if a:0 > 0
+                let l:force_install = a:1
+                if a:0 > 1
+                        let l:script_prolog = a:2
+                endif
+        endif
+
         let l:execute_nvim_path = s:get_firenvim_script_path()
         let l:execute_nvim = s:get_executable_content(s:get_runtime_dir_path(), l:script_prolog)
 
@@ -977,18 +1007,6 @@ function! firenvim#install(...) abort
                         echo 'Created registry key for ' . l:name . '.'
                 endif
         endfor
-
-        if !s:is_wsl
-                let s:is_wsl = has('wsl') || !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
-                if s:is_wsl
-                        echo 'Installation complete on the wsl side. Performing install on the windows side.'
-                        call firenvim#install(l:force_install, l:script_prolog)
-                endif
-        endif
-
-        if luaeval('lvim~=nil')
-                echo 'WARNING: Lunarvim is not supported. Do not open issues if you use Lunarvim.'
-        endif
 endfunction
 
 " Removes files created by Firenvim during its installation process
@@ -999,7 +1017,23 @@ endfunction
 " > Then, we set is_wsl to true if we're on wsl and launch
 " firenvim#uninstall again, uninstalling things on the host side.
 function! firenvim#uninstall() abort
+        try
+                if !s:is_wsl
+                        call firenvim#internal_uninstall()
+                        let s:is_wsl = has('wsl') || !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
+                        if s:is_wsl
+                                echo 'Uninstallation complete on the wsl side. Performing uninstall on the windows side.'
+                                call firenvim#internal_uninstall()
+                        endif
+                else
+                        throw 'firenvim#uninstall is called, but s:is_wsl has not been reset. Please report this bug.'
+                endif
+        finally
+                let s:is_wsl = v:false
+        endtry
+endfunction
 
+function! firenvim#internal_uninstall() abort
         let l:data_dir = s:get_data_dir_path()
         call delete(l:data_dir, 'rf')
         echo 'Removed firenvim data directory.'
@@ -1032,14 +1066,6 @@ function! firenvim#uninstall() abort
                 call delete(l:manifest_path)
                 echo 'Removed native manifest for ' . l:name . '.'
         endfor
-
-        if !s:is_wsl
-                let s:is_wsl = has('wsl') || !empty($WSL_DISTRO_NAME) || !empty ($WSL_INTEROP)
-                if s:is_wsl
-                        echo 'Uninstallation complete on the wsl side. Performing uninstall on the windows side.'
-                        call firenvim#uninstall()
-                endif
-        endif
 endfunction
 
 function! firenvim#onUIEnter(event) abort


### PR DESCRIPTION
The behaviors of `firenvim#install` and `firenvim#uninstall` on WSL are controlled by the script variable `s:is_wsl`: we initialize it to false to (un)install firenvim on wsl side, and then set it to 1 to (un)install on windows host side.

Currently, only `firenvim#install` and `firenvim#uninstall` changes the value of `s:is_wsl`. The two function do not reset `s:is_wsl`, and thus `s:is_wsl` is always 1 after calling them.

As a result, doing the followings sequentially in neovim have unexpected results:

```lua
-- 1. `s:is_wsl` is set to 1
vim.fn["firenvim#install"](0)

-- 2. uninstall firenvim only on windows host because `s:is_wsl` is 1
vim.fn["firenvim#uninstall"]()
```

```lua
-- 1. `s:is_wsl` is set to 1
vim.fn["firenvim#uninstall"]()
-- 2. reinstall, installs scripts on host only, no scripts on WSL
vim.fn["firenvim#install"](0)
```

To fix this, a `try ... finally` block resets `s:is_wsl` even if the two functions throw errors or run unsuccessfully.