### PR TITLE
Fix the NativeMessagingHosts path for Microsoft Edge

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -499,7 +499,7 @@ function! s:get_edge_manifest_dir_path() abort
                 if !isdirectory(s:build_path(l:p))
                         let l:p = [$HOME, 'Library', 'Application Support', 'Microsoft Edge']
                 endif
-                return s:build_path([l:p, 'NativeMessagingHosts'])
+                return s:build_path(l:p + ['NativeMessagingHosts'])
         elseif has('win32') || s:is_wsl
                 return s:get_data_dir_path()
         end


### PR DESCRIPTION
Fix #1651 for real :). Verified locally by command `nvim +'call firenvim#install(0)' +q`. Saw the firenvim.json file installed under `~/Library/Application Support/Microsoft Edge/NativeMessagingHosts`.