### PR TITLE
firenvim.vim: supress error when run Vim (when config folder is the same)

### DIFF
--- a/plugin/firenvim.vim
+++ b/plugin/firenvim.vim
@@ -1,4 +1,8 @@
-if exists('g:firenvim_loaded')
-        finish
+if has('nvim')
+
+    if exists('g:firenvim_loaded')
+            finish
+    endif
+    let g:firenvim_loaded = 1
+
 endif
-let g:firenvim_loaded = 1


### PR DESCRIPTION
My `~/.config/nvim` is a softlink to `~/.config/vim`, I do not want to see firenvim error when using Vim in a terminal.