### PR TITLE
vint.yml: try to get rid of setup-python action

### DIFF
--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -18,10 +18,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.12.8
     - name: Setup dependencies
       run: pip install setuptools vim-vint
     - name: Run Vimscript Linter


### PR DESCRIPTION
vint.yml is failing due to the required python version being
unavailable. Can we stop asking for a specific version?
