### PR TITLE
test.yml: upgrade action-setup-vim to latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         choco install firefox-dev --pre
         echo "C:\Program Files\Firefox Dev Edition" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install Neovim
-      uses: rhysd/action-setup-vim@v1.3.3
+      uses: rhysd/action-setup-vim@v1.4.1
       with:
         neovim: true
         version: ${{ matrix.neovim }}


### PR DESCRIPTION
Hopefully will make the failures to download neovim stable on linux
disappear.
