### PR TITLE
firenvim.vim:get_windows_env_path: deal with inconsistent system()

### DIFF
--- a/autoload/firenvim.vim
+++ b/autoload/firenvim.vim
@@ -160,7 +160,14 @@ function! s:get_windows_env_path(env) abort
                                 throw 'Error: Firenvim could not find cmd.exe from WSL on your system. Please report this issue.'
                         endtry
                 endtry
-                return cmd_output[match(l:cmd_output, 'C:\\'):-3]
+                " cmd_output may contain error strings such as 'UNC paths are
+                " not supported' - thus we need to find the beginning of the
+                " path
+                let l:path = cmd_output[match(l:cmd_output, 'C:\\'):]
+                " Despite system()'s :help claiming that CR will be removed
+                " from the output, we may still have CRs in l:path - thus we
+                " need to trim our result (#1683).
+                return trim(l:path)
         endif
         throw 'Used get_windows_env_path on non-windows platform!'
 endfunction


### PR DESCRIPTION
In #1683, the user reports that get_windows_env_path returns truncated
values for %AppData%, and that replacing the `-3` to `-2` in the value
returned by get_windows_env_path fixes this issue.
On my machine, it seems that `-3` is still the correct value. This is
weird, because system()'s `:help` says that CRs should be stripped from
`system()`'s output, meaning that regardless of whether the system emits
an NL or a CRNL, the string system returns should be consistent.
We just shrug our shoulders at this mistery and start using trim()
instead of hard-coding the amount of characters to remove from
system()'s output in order to fix this.

Closes #1683
