### PR TITLE
chrome: migrate Chrome extension to Manifest V3 with service worker support

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,8 @@
 {
    "background": {
-      "scripts": [ "background.js" ]
+      "service_worker": "background.js"
    },
-   "browser_action": {
-      "browser_style": true,
+   "action": {
       "default_icon": "firenvim.svg",
       "default_popup": "browserAction.html",
       "default_title": "Firenvim"
@@ -39,12 +38,16 @@
    "icons": {
       "128": "firenvim.svg"
    },
-   "manifest_version": 2,
+   "manifest_version": 3,
    "name": "Firenvim",
    "options_ui": {
       "page": "options.html"
    },
+   "host_permissions": [ "<all_urls>" ],
    "permissions": [ "nativeMessaging", "storage" ],
    "version": "replaced_at_compile_time",
-   "web_accessible_resources": [ "index.html", "ISSUE_TEMPLATE.md" ]
+   "web_accessible_resources": [ {
+      "resources": [ "index.html", "ISSUE_TEMPLATE.md" ],
+      "matches": [ "<all_urls>" ]
+   } ]
 }

--- a/src/page.ts
+++ b/src/page.ts
@@ -279,7 +279,9 @@ export class PageEventEmitter extends EventEmitter<PageEvents, PageHandlers> {
                     // handled by frame function handler
                     break;
                 default:
-                    console.error("Unhandled page request:", request);
+                    // Messages may be broadcast to multiple listeners
+                    // Only log at debug level since this is expected
+                    console.debug("Unhandled page request:", request);
             }
         });
     }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -51,7 +51,7 @@ export function setCanvas (cvs: HTMLCanvasElement) {
     const canvasDefaultFontSize = window.getComputedStyle(state.canvas).fontSize;
     defaultFontSize = `calc(${window.devicePixelRatio} * ${canvasDefaultFontSize})`;
     defaultFontString = makeFontString(defaultFontSize, defaultFontFamily);
-    state.context = state.canvas.getContext("2d", { "alpha": false });
+    state.context = state.canvas.getContext("2d", { "alpha": false, "willReadFrequently": true });
     setFontString(state, defaultFontString);
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,9 +100,11 @@ const chromeConfig = (config, env) => {
             "16": "firenvim16.png",
             "48": "firenvim48.png"
           }
-          manifest.browser_action["default_icon"] = "firenvim128.png";
+          manifest.action["default_icon"] = "firenvim128.png";
           if (env.endsWith("testing")) {
-            manifest.content_security_policy = "script-src 'self' 'unsafe-eval'; object-src 'self';"
+            manifest.content_security_policy = {
+              extension_pages: "script-src 'self' 'unsafe-eval'; object-src 'self';"
+            };
           }
           content = JSON.stringify(manifest, undefined, 3);
         }
@@ -137,10 +139,14 @@ const firefoxConfig = (config, env) => {
           switch(path.basename(src)) {
             case "manifest.json":
               const manifest = JSON.parse(content.toString());
+              // Firefox MV3 uses scripts instead of service_worker
+              manifest.background = {
+                "scripts": ["background.js"]
+              };
               manifest.browser_specific_settings = {
                 "gecko": {
                   "id": "firenvim@lacamb.re",
-                  "strict_min_version": "88.0"
+                  "strict_min_version": "109.0"
                 }
               };
               manifest.version = package_json.version;


### PR DESCRIPTION
# Changes

**Manifest V3 Migration** (`src/manifest.json`)
- Updated `manifest_version` from 2 to 3
- Changed `browser_action` to `action`
- Migrated `background.scripts` to `background.service_worker`
- Added `host_permissions` array for required permissions
- Updated `web_accessible_resources` to MV3 object format

**Service Worker Compatibility** (`src/background.ts`)
- Replaced `window.crypto` with `globalThis.crypto` for service worker compatibility
- Changed all `window` references to `globalThis` to work in service worker context
- Updated `browser.browserAction.setIcon()` to `browser.action.setIcon()` for MV3 API

**Browser Detection Fix** (`src/utils/utils.ts`)
- Fixed "window is not defined" error in service workers by making browser detection lazy
- Added service worker fallback using `browser.runtime.getBrowserInfo` instead of `window.location`
- Previously top-level code accessed `window.location` at module load time, breaking service workers

**Icon Generation Dual-Path** (`src/utils/utils.ts`)
- Service workers use `OffscreenCanvas` with PNG since `createImageBitmap()` doesn't support SVG
- DOM contexts continue using regular canvas with SVG (unchanged)
- Runtime detection via `typeof window === 'undefined' || typeof document === 'undefined'`

**Canvas Performance Optimization** (`src/utils/utils.ts`, `src/renderer.ts`)
- Added `{ willReadFrequently: true }` to all canvas context creation to fix Chrome performance warnings

**Webpack Configuration** (`webpack.config.js`)
- Chrome builds use `service_worker` for background
- Firefox builds explicitly override to use `scripts: ["background.js"]` (Firefox MV3 still supports background scripts)
- Updated Firefox minimum version to 109.0
- Fixed CSP format for MV3 testing builds

# Why This Approach

**Firefox Compatibility**: Firefox MV3 background scripts retain `window`/`document` access, so webpack explicitly configures Firefox to use `scripts` mode. The runtime detection ensures the existing SVG code path is taken.

**Chrome Service Workers**: Chrome MV3 requires true service workers without DOM access, so we use OffscreenCanvas with a pre-generated PNG for icon generation.

closes #1674 