### PR TITLE
doc(README): add Firefox AutoConfig instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,88 @@ vim.g.firenvim_config = {
 
 Note that on Firefox on Linux some keyboard shortcuts might not be overridable. I circumvent this issue by running a [patched](https://github.com/glacambre/firefox-patches) version of Firefox (note: once Firefox is patched, you won't need to setup webextension keyboard shortcuts).
 
+Alternatively, you can customize Firefox using [AutoConfig](https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig). You need to place two files (may require Administrator privileges or `sudo`):
+
+1. A config loader in the Firefox defaults directory (e.g., `C:/Program Files/Mozilla Firefox/defaults/pref/autoconfig.js`, `/usr/lib/firefox/defaults/pref/autoconfig.js`, or `/Applications/Firefox.app/Contents/Resources/defaults/pref/autoconfig.js`)
+
+```javascript
+/* vim: set fileformat=unix filetype=javascript: */
+// autoconfig.js must use LF (Unix EOL)
+
+// name of the config file; you can use firefox.js or any name you prefer
+pref("general.config.filename", "firefox.cfg");
+pref("general.config.obscure_value", 0);
+// enable privileged js code in firefox.cfg
+pref("general.config.sandbox_enabled", false);
+```
+
+2. The actual config file in the Firefox installation directory (e.g., `C:/Program Files/Mozilla Firefox/firefox.cfg`, `/usr/lib/firefox/firefox.cfg`, or `/Applications/Firefox.app/Contents/Resources/firefox.cfg`)
+
+```javascript
+/* vim: set fileformat=unix filetype=javascript: */
+// IMPORTANT: Start your code on the 2nd line.
+// firefox.cfg: filename in general.config.filename
+
+// pre-Fx117: const { Services } = Components.utils.import('resource://gre/modules/Services.jsm');
+const { Services } = globalThis;
+
+function ConfigJS() {
+  Services.obs.addObserver(this, "chrome-document-global-created", false);
+}
+ConfigJS.prototype = {
+  observe: function (aSubject, topic) {
+    if (topic === "chrome-document-global-created") {
+      aSubject.addEventListener("DOMContentLoaded", this, { once: true });
+    }
+  },
+  handleEvent: function (aEvent) {
+    const document = aEvent.originalTarget;
+    const window = document.defaultView;
+    const location = window.location;
+    if (
+      /^(chrome:(?!\/\/(global\/content\/commonDialog|browser\/content\/webext-panels)\.x?html)|about:(?!blank))/i.test(
+        location.href,
+      )
+    ) {
+      // @deprecated: window._gBrowser is undefined on newer Firefox
+      if (window.gBrowserInit || window._gBrowser) {
+        // for firenvim
+        const reservedKeys = [
+          "key_newNavigator", // <C-n>
+          "key_newNavigatorTab", // <C-t>
+          "key_close", // <C-w>
+          // additional reserved keys
+          // "key_closeWindow", // <C-S-w>
+          // "key_quitApplication", // <C-S-q>
+          // "key_privatebrowsing", // <C-S-p>
+        ];
+        for (const keyId of reservedKeys) {
+          const keyCommand = window.document.getElementById(keyId);
+          if (!keyCommand) {
+            throw new Error(`autoconfig: ${keyId} not found.`);
+          }
+          // remove `reserved` attribute to mark key as non-reserved
+          keyCommand.removeAttribute("reserved");
+        }
+      }
+    }
+  },
+};
+
+try {
+  if (!Services.appinfo.inSafeMode) {
+    new ConfigJS();
+  }
+} catch (error) {
+  Services.prompt.alert(
+    null,
+    "AutoConfig",
+    `Exception caught in FIREFOX_ROOT/firefox.cfg.
+Message: ${error.message}\nTrace: ${error.stack}`,
+  );
+}
+```
+
 ## You might also like
 
 - [Tridactyl](https://github.com/tridactyl/tridactyl), provides vim-like keybindings to use Firefox. Also lets you edit input fields and text areas in your favourite editor with its `:editor` command.


### PR DESCRIPTION
Firefox introduced [AutoConfig](https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig) to allow users customize the browser. It is a more user-friendly alternative to the patched version. Please review the code in the instructions and test this in Firefox.