### PR TITLE
towards a manifest v3

### DIFF
--- a/src/autofill.ts
+++ b/src/autofill.ts
@@ -5,19 +5,10 @@ export async function autofill() {
         return;
     }
     const platInfoPromise = browser.runtime.sendMessage({
-        args: {
-            args: [],
-            funcName: ["browser", "runtime", "getPlatformInfo"],
-        },
-        funcName: ["exec"],
+        args: [],
+        funcName: ["getPlatformInfo"],
     });
-    const manifestPromise = browser.runtime.sendMessage({
-        args: {
-            args: [],
-            funcName: ["browser", "runtime", "getManifest"],
-        },
-        funcName: ["exec"],
-    });
+    const manifest = browser.runtime.getManifest();
     const nvimPluginPromise = browser.runtime.sendMessage({
         args: {},
         funcName: ["getNvimPluginVersion"],
@@ -37,10 +28,9 @@ export async function autofill() {
     const vendor = navigator.vendor || "";
     const [
         platInfo,
-        manifest,
         nvimPluginVersion,
         issueTemplate,
-    ] = await Promise.all([platInfoPromise, manifestPromise, nvimPluginPromise, issueTemplatePromise]);
+    ] = await Promise.all([platInfoPromise, nvimPluginPromise, issueTemplatePromise]);
     // Can't happen, but doesn't cost much to handle!
     /* istanbul ignore next */
     if (textarea.value.replace(/\r/g, "") !== issueTemplate.replace(/\r/g, "")) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -163,7 +163,7 @@ function applySettings(settings: any) {
     return browser.storage.local.set(mergeWithDefaults(os, settings) as any);
 }
 
-function updateSettings() {
+export function updateSettings() {
     const tmp = preloadedInstance;
     preloadedInstance = createNewInstance();
     tmp.then(nvim => nvim.kill());
@@ -219,7 +219,7 @@ async function toggleDisabled() {
     return browser.tabs.sendMessage(tabid, { args: [disabled], funcName: ["setDisabled"] });
 }
 
-async function acceptCommand (command: string) {
+export async function acceptCommand (command: string) {
     const tab = (await browser.tabs.query({ active: true, currentWindow: true }))[0];
     let p;
     switch (command) {
@@ -288,14 +288,9 @@ async function acceptCommand (command: string) {
     return p;
 }
 
-Object.assign(window, {
-    acceptCommand,
-    // We need to stick the browser polyfill in `window` if we want the `exec`
-    // call to be able to find it on Chrome
-    browser,
+const handlers: { [name: string]: (sender: any, args: any) => any } = {
     closeOwnTab: (sender: any) => browser.tabs.remove(sender.tab.id),
-    exec: (_: any, args: any) => args.funcName.reduce((acc: any, cur: string) => acc[cur], window)(...(args.args)),
-    getError,
+    getError: () => getError(),
     getNeovimInstance: () => {
         const result = preloadedInstance;
         preloadedInstance = createNewInstance();
@@ -303,11 +298,12 @@ Object.assign(window, {
         return result.then(({ password, port }) => ({ password, port }));
     },
     getNvimPluginVersion: () => nvimPluginVersion,
+    getPlatformInfo: () => browser.runtime.getPlatformInfo(),
     getOwnFrameId: (sender: any) => sender.frameId,
     getTab: (sender: any) => sender.tab,
     getTabValue: (sender: any, args: any) => getTabValue(sender.tab.id, args[0]),
     getTabValueFor: (_: any, args: any) => getTabValue(args[0], args[1]),
-    getWarning,
+    getWarning: () => getWarning(),
     messageFrame: (sender: any, args: any) => browser.tabs.sendMessage(sender.tab.id,
                                                                        args.message,
                                                                        { frameId: args.frameId }),
@@ -324,13 +320,13 @@ Object.assign(window, {
     toggleDisabled: () => toggleDisabled(),
     updateSettings: () => updateSettings(),
     openTroubleshootingGuide: () => browser.tabs.create({ active: true, url: "https://github.com/glacambre/firenvim/blob/master/TROUBLESHOOTING.md" }),
-} as any);
+};
 
 browser.runtime.onMessage.addListener(async (request: any, sender: any, _sendResponse: any) => {
-    const fn = request.funcName.reduce((acc: any, cur: string) => acc[cur], window);
+    const fn = handlers[request.funcName[0]];
     // Can't be tested as there's no way to force an incorrect content request.
     /* istanbul ignore next */
-    if (!fn) {
+    if (!fn || request.funcName.length !== 1) {
         throw new Error(`Error: unhandled content request: ${JSON.stringify(request)}.`);
     }
     return fn(sender, request.args !== undefined ? request.args : []);
@@ -356,7 +352,7 @@ browser.runtime.onMessageExternal.addListener(async (request: any, sender: any, 
 
 const UPDATE_CHECK_ALARM = "firenvim-update-check";
 
-async function updateIfPossible() {
+export async function updateIfPossible() {
     const tabs = await browser.tabs.query({});
     const messages = tabs.map(tab => browser
                                         .tabs
@@ -377,7 +373,6 @@ async function updateIfPossible() {
         browser.alarms.create(UPDATE_CHECK_ALARM, { delayInMinutes: 10 });
     }
 }
-(window as any).updateIfPossible = updateIfPossible;
 browser.runtime.onUpdateAvailable.addListener(updateIfPossible);
 browser.alarms.onAlarm.addListener((alarm: any) => {
     if (alarm.name === UPDATE_CHECK_ALARM) {

--- a/src/browserAction.ts
+++ b/src/browserAction.ts
@@ -13,13 +13,7 @@ function displayErrorsAndWarnings() {
 }
 
 async function updateDisableButton() {
-    const tabId = (await browser.runtime.sendMessage({
-        args: {
-            args: [{ active: true, currentWindow: true }],
-            funcName: [ "browser", "tabs", "query" ],
-        },
-        funcName: ["exec"],
-    }))[0].id;
+    const tabId = (await browser.tabs.query({ active: true, currentWindow: true }))[0].id;
     const disabled = (await browser.runtime.sendMessage({
         args: [tabId, "disabled"],
         funcName: ["getTabValueFor"],

--- a/src/testing/background.ts
+++ b/src/testing/background.ts
@@ -7,4 +7,9 @@ background.preloadedInstance.then(() => console.log("preloaded instance loaded!"
 const socket = new WebSocket('ws://127.0.0.1:12345');
 socket.addEventListener('message', makeRequestHandler(socket,
                                                       "background",
-                                                      (window as any).__coverage__ || /* istanbul ignore next */ {}));
+                                                      (self as any).__coverage__ || /* istanbul ignore next */ {},
+                                                      {
+                                                          updateSettings: background.updateSettings,
+                                                          updateIfPossible: background.updateIfPossible,
+                                                          acceptCommand: background.acceptCommand,
+                                                      }));

--- a/src/testing/rpc.ts
+++ b/src/testing/rpc.ts
@@ -1,4 +1,14 @@
 
+// Background-only actions. Passed in by testing/background.ts; testing/content
+// and testing/frame omit the parameter, since the request types that need
+// these (updateSettings/tryUpdate/acceptCommand) are only ever sent to the
+// background context.
+export type BackgroundActions = {
+    updateSettings: () => Promise<unknown>;
+    updateIfPossible: () => Promise<unknown>;
+    acceptCommand: (command: string) => Promise<unknown>;
+};
+
 const requests = new Map();
 
 let reqId = 0;
@@ -12,7 +22,7 @@ export function makeRequest(socket: any, func: string, args?: any[]): any {
     });
 }
 
-export function makeRequestHandler(s: any, context: string, coverageData: any) {
+export function makeRequestHandler(s: any, context: string, coverageData: any, actions?: BackgroundActions) {
     return async (m: any) => {
         const req = JSON.parse(m.data);
         const resolve = (args: any[]) => s.send(JSON.stringify({
@@ -64,7 +74,7 @@ export function makeRequestHandler(s: any, context: string, coverageData: any) {
                 /* istanbul ignore next */
                 break;
             case "updateSettings":
-                (window as any).updateSettings().finally(() => {
+                actions.updateSettings().finally(() => {
                     s.send(JSON.stringify({
                         args: [],
                         funcName: ["resolve"],
@@ -73,7 +83,7 @@ export function makeRequestHandler(s: any, context: string, coverageData: any) {
                 });
                 break;
             case "tryUpdate":
-                (window as any).updateIfPossible().finally(() => {
+                actions.updateIfPossible().finally(() => {
                     s.send(JSON.stringify({
                         args: [],
                         funcName: ["resolve"],
@@ -82,7 +92,7 @@ export function makeRequestHandler(s: any, context: string, coverageData: any) {
                 });
                 break;
             case "acceptCommand":
-                (window as any).acceptCommand(...req.args).finally(() => {
+                actions.acceptCommand(req.args[0]).finally(() => {
                     s.send(JSON.stringify({
                         args: [],
                         funcName: ["resolve"],

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,23 +1,10 @@
-let curHost : string;
+// browser.runtime.getURL("") returns "moz-extension://…/" on Firefox and
+// "chrome-extension://…/" on Chrome. Works in content scripts, extension pages,
+// and service workers — unlike `window.location.protocol`, which doesn't exist
+// in a service worker.
+const curHost = browser.runtime.getURL("").startsWith("moz-extension:") ? "firefox" : "chrome";
 
-// Chrome doesn't have a "browser" object, instead it uses "chrome".
-if (window.location.protocol === "moz-extension:") {
-    curHost = "firefox";
-} else if (window.location.protocol === "chrome-extension:") {
-    curHost = "chrome";
-} else if ((window as any).InstallTrigger === undefined) {
-    curHost = "chrome";
-} else {
-    curHost = "firefox";
-}
-
-// Only usable in background script!
 export function isChrome() {
-    // Can't cover error condition
-    /* istanbul ignore next */
-    if (curHost === undefined) {
-        throw Error("Used isChrome in content script!");
-    }
     return curHost === "chrome";
 }
 

--- a/tests/firefox.ts
+++ b/tests/firefox.ts
@@ -114,6 +114,31 @@ describe("Firefox", () => {
                 const options = (new Options())
                         .setPreference("xpinstall.signatures.required", false)
                         .setPreference("remote.active-protocols", 3)
+                        .setPreference("browser.uiCustomization.state", JSON.stringify({
+                                placements: {
+                                        "widget-overflow-fixed-list": [],
+                                        "nav-bar": [
+                                                "back-button",
+                                                "forward-button",
+                                                "stop-reload-button",
+                                                "urlbar-container",
+                                                "downloads-button",
+                                                "fxa-toolbar-menu-button",
+                                                "firenvim_lacamb_re-browser-action",
+                                        ],
+                                        "toolbar-menubar": ["menubar-items"],
+                                        "TabsToolbar": [
+                                                "firefox-view-button",
+                                                "tabbrowser-tabs",
+                                                "new-tab-button",
+                                                "alltabs-button",
+                                        ],
+                                        "PersonalToolbar": ["personal-bookmarks"],
+                                },
+                                seen: ["firenvim_lacamb_re-browser-action"],
+                                currentVersion: 20,
+                                newElementCount: 4,
+                        }))
                         .addExtensions(extensionPath);
 
                 if (firefoxPath) {


### PR DESCRIPTION
- utils.ts: do not rely on window.location.protocol for browser detection
- browserAction.ts: simplify call to browser.tabs.query
- tests/firefox.ts: ensure browserAction appears in firefox interface
- background: stop attaching RPC handlers to window
