### PR TITLE
fix(close_server): early return for nil handle

### DIFF
--- a/lua/firenvim.lua
+++ b/lua/firenvim.lua
@@ -1,6 +1,9 @@
 local websocket = require("firenvim-websocket")
 
 local function close_server(server)
+        if not server then
+                return
+        end
         vim.loop.close(server)
         -- Work around https://github.com/glacambre/firenvim/issues/49 Note:
         -- important to do this before nvim_command("qall") because it breaks


### PR DESCRIPTION
`close_server` does not check nil value when passing argument to `vim.loop.close`. An early return prevents unintended side effects.

Related: #1719