### PR TITLE
Harden Lua server teardown and improve startup diagnostics

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -12,6 +12,22 @@ flatpak permissions webextensions
 
 If the output of this command shows that Snap/Flatpak are preventing Firenvim from running, you need to run `flatpak permission-set webextensions firenvim snap.firefox yes` to change that.
 
+## LibreWolf / Firefox: Local Network Access (LNA) blocks the WebSocket
+
+Recent versions of Firefox and LibreWolf enable **Local Network Access** checks for WebSockets. Firenvim connects the editor frame to Neovim via `ws://127.0.0.1:<random-port>`, so if LNA is enforced for WebSockets the frame cannot connect and the Firenvim UI appears for a split second and immediately closes. The browser console will show an error like:
+
+```
+Firefox/LibreWolf can’t establish a connection to the server at ws://127.0.0.1:<port>/...
+```
+
+`network.lna.local-network-to-localhost.skip-checks` does not help here because extension pages (`moz-extension://...`) are not treated as "private network" origins. There is currently no WebExtension API or per-extension LNA exception, so the only practical workaround is to disable LNA for WebSockets globally:
+
+- Open `about:config`.
+- Set `network.lna.websocket.enabled` to `false`.
+- Reload Firenvim or restart the browser.
+
+Note that this removes LNA protection for **all** WebSocket connections (websites can then probe `127.0.0.1`/private IPs over WebSockets without a prompt), so it is a security/privacy trade-off.
+
 ## Make sure the Neovim plugin is installed
 
 Run Neovim without any arguments and then try to run the following line:

--- a/lua/firenvim.lua
+++ b/lua/firenvim.lua
@@ -1,7 +1,9 @@
 local websocket = require("firenvim-websocket")
 
 local function close_server(server)
-        vim.loop.close(server)
+        if server ~= nil and not server:is_closing() then
+                server:close()
+        end
         -- Work around https://github.com/glacambre/firenvim/issues/49 Note:
         -- important to do this before nvim_command("qall") because it breaks
         vim.loop.new_timer():start(1000, 100, (function() os.exit() end))
@@ -32,7 +34,7 @@ local function connection_handler(server, sock, token)
         return function(err, chunk)
                 assert(not err, err)
                 if not chunk then
-                        return close_server()
+                        return close_server(server)
                 end
                 local _
                 if not headers then

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -217,7 +217,7 @@ export const isReady = browser
                 // to write the file, which requires too many os-dependent side
                 // effects), so don't instrument.
                 /* istanbul ignore next */
-                writeFilePromise.catch(() => reject());
+                writeFilePromise.catch((e: any) => { console.error("writeFilePromise failed:", e); reject(e); });
             }, 10));
         } catch (e) {
             console.error(e);


### PR DESCRIPTION
## Description

- `lua/firenvim.lua`: guard close_server against `nil` and already-closing server handles, switch from `vim.loop.close(server)` to `server:close()`, and pass the server argument in the `chunk == nil` handler. This prevents `vim.loop.close(nil)` from aborting shutdown and ensures `qall!` runs.
- `src/frame.ts`: log and propagate `writeFilePromise` rejections so `writefile/:edit` failures are visible in the frame console instead of being swallowed.
- `TROUBLESHOOTING.md`: document the LibreWolf/Firefox Local Network Access block on `ws://127.0.0.1` and the `network.lna.websocket.enabled=false` workaround (with the security/privacy trade-off noted).

## Test plan

- Build the extension with `npm run build`.
- Test Firenvim on a page with a `textarea`, on a Firefox version configured with `network.lna.websocket.enabled=false`; confirm the frame no longer crashes during server teardown.
- If possible, trigger a `writefile/:edit` failure and verify the error is logged in the frame console.
- On LibreWolf/Firefox with `network.lna.websocket.enabled=true`, confirm the documented LNA behavior and workaround.